### PR TITLE
Add in support for smaller time increments

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -24,6 +24,57 @@ Documentation
 -------------
 Forthcoming...
 
+    *showWeekends; default to true
+      * boolean value to determine 
+    * data
+      * the data object; no default
+    * buffer; default to 1 day buffer
+      * number of days to add to the grid pre/post start/end
+    * cellBuffer; default to 5 cells
+      * number of cells to display prior to the start time
+    * dateChunks; default to 1 for backwards compatibility
+      * how many chunks to split each day into [ie how many cells make up one day]
+        * 1 = daily, 24 = hourly, 1440 = by minutes but can be any number
+    * freezeDate; default to null
+      * date before which to allow no edits 
+        * NOTE: A TASK CAN STILL BE RESIZED SUCH THAT IT'S END APPEARS TO BE BEHIND THE FREEZEDATE; HOWEVER, THE SAVED END DATE IS CORRECT
+    * displayGroupedTitles; default to true to maintain backwards compatibility
+      * boolean value to determine whether to list all block titles
+    * reorder; defaults to true to maintain backwards compatibility
+      * boolean value setting whether or not tasks can be reordered
+    * displayHoursOnBlock; defaults to true to maintain backwards compatibility
+      * boolean value setting whether or not the duration in hours should be displayed on the block
+    * updateDependencies; default to false to maintain backwards compatibility
+      * boolean value to determine whether to update all of the following items in a series when the preceding one's end date is changed
+    * doNotDisplayTagged; default to [] to maintain backwards compatibility
+      * array of strings to ignore from data
+    * cellWidth; default to 21
+      * width of each cell on the grid
+    * cellHeight; default to 31
+      * height of each cell on the grid
+    *slideWidth; default to 400
+      * width of the displayed portion of the grid
+    * groupBySeries; default to false
+      * boolean value to determine whether to list all tasks under the same series on the same row
+    * groupById; default to false
+      * boolean value to determine whether to list all tasks with the same id on the same row
+    * groupByIdDrawAllTitles; default to false
+      * boolean value to determine whether to draw all titles if grouped by id (?)
+    * vHeaderWidth; default to 100
+      * width of the section to the right of the grid
+    * behavior
+      * clickable; default to true
+        * boolean value to determine whether the tasks can be clicked
+      * draggable; default to true
+        * boolean value to determine whether the tasks can be dragged to new locations
+      * resizable; default to true
+        * boolean value to determine whether tasks can be resized
+      * onClick
+        * function that is run whenever a task is clicked
+      * onDrag
+        * function that is run whenever a task is dragged
+      * onResize
+        * function that is run whenever a task is resized
 
 Contribution Guidelines
 ------------

--- a/example/index.html
+++ b/example/index.html
@@ -27,24 +27,32 @@
 	<script type="text/javascript" src="../jquery.ganttView.js"></script>
 	<script type="text/javascript" src="data.js"></script>
 	<script type="text/javascript">
+		var updatedData = [];
 		$(function () {
 			$("#ganttChart").ganttView({ 
 				data: ganttData,
 				slideWidth: 900,
 				groupBySeries: true,
 				dateChunks: 24,
+				updateDependencies: true,
 				behavior: {
 					onClick: function (data) { 
-						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy hh:mm") + ", end: " + data.end.toString("M/d/yyyy hh:mm") + " }";
+						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy H:MM") + ", end: " + data.end.toString("M/d/yyyy H:MM") + " }";
 						$("#eventMessage").text(msg);
 					},
-					onResize: function (data) { 
-						var msg = "You resized an event: { start: " + data.start.toString("M/d/yyyy hh:mm") + ", end: " + data.end.toString("M/d/yyyy hh:mm") + " }";
+					onResize: function (uData) { 
+						var msg = "You resized an event: { start: " + uData[uData.length-1].start.toString("M/d/yyyy H:MM") + ", end: " + uData[uData.length-1].end.toString("M/d/yyyy H:MM") + " }";
 						$("#eventMessage").text(msg);
+						//call function updateIfChanged
+						updatedData = uData;
+						console.log(updatedData);
 					},
-					onDrag: function (data) { 
-						var msg = "You dragged an event: { start: " + data.start.toString("M/d/yyyy hh:mm") + ", end: " + data.end.toString("M/d/yyyy hh:mm") + " }";
+					onDrag: function (uData) { 
+						var msg = "You dragged an event: { start: " + uData[uData.length-1].start.toString("M/d/yyyy H:MM") + ", end: " + uData[uData.length-1].end.toString("M/d/yyyy H:MM") + " }";
 						$("#eventMessage").text(msg);
+						//call function updateIfChanged
+						updatedData = uData;
+						console.log(updatedData);
 					}
 				}
 			});

--- a/example/index.html
+++ b/example/index.html
@@ -28,6 +28,11 @@
 	<script type="text/javascript" src="data.js"></script>
 	<script type="text/javascript">
 		var updatedData = [];
+
+		var freezeDate = new Date();
+		freezeDate.setYear(2010);
+		freezeDate.setMonth(0);
+		freezeDate.setDate(2);
 		$(function () {
 			$("#ganttChart").ganttView({ 
 				data: ganttData,
@@ -35,6 +40,7 @@
 				groupBySeries: true,
 				dateChunks: 24,
 				updateDependencies: true,
+				freezeDate,
 				behavior: {
 					onClick: function (data) { 
 						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy H:mm") + ", end: " + data.end.toString("M/d/yyyy H:mm") + " }";

--- a/example/index.html
+++ b/example/index.html
@@ -37,18 +37,18 @@
 				updateDependencies: true,
 				behavior: {
 					onClick: function (data) { 
-						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy H:MM") + ", end: " + data.end.toString("M/d/yyyy H:MM") + " }";
+						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy H:mm") + ", end: " + data.end.toString("M/d/yyyy H:mm") + " }";
 						$("#eventMessage").text(msg);
 					},
 					onResize: function (uData) { 
-						var msg = "You resized an event: { start: " + uData[uData.length-1].start.toString("M/d/yyyy H:MM") + ", end: " + uData[uData.length-1].end.toString("M/d/yyyy H:MM") + " }";
+						var msg = "You resized an event: { start: " + uData[uData.length-1].start.toString("M/d/yyyy H:mm") + ", end: " + uData[uData.length-1].end.toString("M/d/yyyy H:mm") + " }";
 						$("#eventMessage").text(msg);
 						//call function updateIfChanged
 						updatedData = uData;
 						console.log(updatedData);
 					},
 					onDrag: function (uData) { 
-						var msg = "You dragged an event: { start: " + uData[uData.length-1].start.toString("M/d/yyyy H:MM") + ", end: " + uData[uData.length-1].end.toString("M/d/yyyy H:MM") + " }";
+						var msg = "You dragged an event: { start: " + uData[uData.length-1].start.toString("M/d/yyyy H:mm") + ", end: " + uData[uData.length-1].end.toString("M/d/yyyy H:mm") + " }";
 						$("#eventMessage").text(msg);
 						//call function updateIfChanged
 						updatedData = uData;
@@ -60,6 +60,5 @@
 			// $("#ganttChart").ganttView("setSlideWidth", 600);
 		});
 	</script>
-
 </body>
 </html>

--- a/example/index.html
+++ b/example/index.html
@@ -32,19 +32,18 @@
 				data: ganttData,
 				slideWidth: 900,
 				groupBySeries: true,
-				groupById: true,
-				groupByIdDrawAllTitles: true,
+				dateChunks: 24,
 				behavior: {
 					onClick: function (data) { 
-						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy") + ", end: " + data.end.toString("M/d/yyyy") + " }";
+						var msg = "You clicked on an event: { start: " + data.start.toString("M/d/yyyy hh:mm") + ", end: " + data.end.toString("M/d/yyyy hh:mm") + " }";
 						$("#eventMessage").text(msg);
 					},
 					onResize: function (data) { 
-						var msg = "You resized an event: { start: " + data.start.toString("M/d/yyyy") + ", end: " + data.end.toString("M/d/yyyy") + " }";
+						var msg = "You resized an event: { start: " + data.start.toString("M/d/yyyy hh:mm") + ", end: " + data.end.toString("M/d/yyyy hh:mm") + " }";
 						$("#eventMessage").text(msg);
 					},
 					onDrag: function (data) { 
-						var msg = "You dragged an event: { start: " + data.start.toString("M/d/yyyy") + ", end: " + data.end.toString("M/d/yyyy") + " }";
+						var msg = "You dragged an event: { start: " + data.start.toString("M/d/yyyy hh:mm") + ", end: " + data.end.toString("M/d/yyyy hh:mm") + " }";
 						$("#eventMessage").text(msg);
 					}
 				}

--- a/jquery.ganttView.css
+++ b/jquery.ganttView.css
@@ -116,6 +116,9 @@ div.ganttview-grid-row-cell.ganttview-weekend {
     background-color: #fafafa;
 }
 
+div.ganttview-grid-row-cell.ganttview-frozen {
+    background-color: #d1d1d1;
+}
 
 /* Blocks */
 

--- a/jquery.ganttView.css
+++ b/jquery.ganttView.css
@@ -116,8 +116,12 @@ div.ganttview-grid-row-cell.ganttview-weekend {
     background-color: #fafafa;
 }
 
+div.ganttview-grid-row-cell.ganttview-weekend.ganttview-frozen {
+    background-color: #e4e4e4;
+}
+
 div.ganttview-grid-row-cell.ganttview-frozen {
-    background-color: #d1d1d1;
+    background-color: #e9e9e9;
 }
 
 /* Blocks */

--- a/jquery.ganttView.css
+++ b/jquery.ganttView.css
@@ -12,144 +12,157 @@ div.ganttview-vtheader-item-name,
 div.ganttview-vtheader-series,
 div.ganttview-grid,
 div.ganttview-grid-row-cell {
-	float: left;
+    float: left;
 }
 
 div.ganttview-hzheader-month,
-div.ganttview-hzheader-day,
+div.ganttview-hzheader-day {
+    text-align: center;
+}
+
 div.ganttview-hzheader-chunk {
-	text-align: center;
+    text-align: left;
 }
 
 div.ganttview-grid-row-cell.last,
 div.ganttview-hzheader-day.last,
 div.ganttview-hzheader-chunk.last,
 div.ganttview-hzheader-month.last {
-	border-right: none;
+    border-right: none;
 }
 
 div.ganttview {
-	border: 1px solid #999;
+    border: 1px solid #999;
 }
 
 
 /* Horizontal Header */
 
 div.ganttview-hzheader-month {
-	width: 60px;
-	height: 20px;
-	border-right: 1px solid #d0d0d0;
-	line-height: 20px;
+    width: 60px;
+    height: 20px;
+    border-right: 1px solid #d0d0d0;
+    line-height: 20px;
 }
 
 div.ganttview-hzheader-day {
-	width: 20px;
-	height: 20px;
-	border-right: 1px solid #f0f0f0;
-	border-top: 1px solid #d0d0d0;
-	line-height: 20px;
-	color: #777;
+    width: 20px;
+    height: 20px;
+    border-right: 1px solid #000000;
+    border-top: 1px solid #d0d0d0;
+    line-height: 20px;
+    color: #777;
+}
+
+div.ganttview-hzheader-chunk {
+    width: 20px;
+    height: 20px;
+    border-right: 1px solid #f0f0f0;
+    border-top: 1px solid #d0d0d0;
+    line-height: 20px;
+    color: #777;
+    font-size: 0.665em;
 }
 
 
 /* Vertical Header */
 
 div.ganttview-vtheader {
-	margin-top: 41px;
-	width: 240px;
-	overflow: hidden;
-	background-color: #fff;
+    margin-top: 61px;
+    width: 240px;
+    overflow: hidden;
+    background-color: #fff;
 }
 
 div.ganttview-vtheader-item {
-	overflow: hidden;
-	color: #666;
+    overflow: hidden;
+    color: #666;
 }
 
 div.ganttview-vtheader-item-name {
-	width: 100px;
-	padding-left: 5px;
-	border-top: 1px solid #d0d0d0;
-	line-height: 16px;
+    width: 100px;
+    padding-left: 5px;
+    border-top: 1px solid #d0d0d0;
+    line-height: 16px;
 }
 
 div.ganttview-vtheader-series-name {
-	width: 130px;
-	height: 31px;
-	border-top: 1px solid #d0d0d0;
-	line-height: 16px;
-	padding-left: 5px;
+    width: 130px;
+    height: 31px;
+    border-top: 1px solid #d0d0d0;
+    line-height: 16px;
+    padding-left: 5px;
 }
 
 
 /* Slider */
 
 div.ganttview-slide-container {
-	overflow: auto;
-	border-left: 1px solid #999;
+    overflow: auto;
+    border-left: 1px solid #000000;
 }
 
 
 /* Grid */
 
 div.ganttview-grid-row-cell {
-	width: 20px;
-	height: 100%;
-	border-right: 1px solid #f0f0f0;
-	border-top: 1px solid #f0f0f0;
+    width: 20px;
+    height: 100%;
+    border-right: 1px solid #f0f0f0;
+    border-top: 1px solid #f0f0f0;
 }
 
 div.ganttview-grid-row-cell.ganttview-weekend {
-	background-color: #fafafa;
+    background-color: #fafafa;
 }
 
 
 /* Blocks */
 
 div.ganttview-blocks {
-	margin-top: 40px;
-  opacity: 0.8;
+    margin-top: 60px;
+    opacity: 0.8;
 }
 
 div.ganttview-block:hover {
-  z-index: 9999;
-  opacity: 1;
+    z-index: 9999;
+    opacity: 1;
 }
 
 div.ganttview-block-container {
-	height: 28px;
-	padding-top: 4px;
+    height: 28px;
+    padding-top: 4px;
     position: relative;
 }
 
 div.ganttview-block {
-	position: absolute;
+    position: absolute;
     margin-top: 4px;
-	height: 25px;
-	background-color: #E5ECF9;
-	border: 1px solid #c0c0c0;
-	border-radius: 3px;
-	-moz-border-radius: 3px;
-	-webkit-border-radius: 3px;
-	opacity: 0.8;
+    height: 25px;
+    background-color: #E5ECF9;
+    border: 1px solid #c0c0c0;
+    border-radius: 3px;
+    -moz-border-radius: 3px;
+    -webkit-border-radius: 3px;
+    opacity: 0.8;
 }
 
 div.ganttview-block:hover {
-	z-index: 9999;
-	opacity: 1;
+    z-index: 9999;
+    opacity: 1;
 }
 
 div.ganttview-block-text {
-	position: absolute;
-	height: 12px;
-	font-size: 0.8em;
-	color: #999;
-	padding: 2px 3px;
+    position: absolute;
+    height: 12px;
+    font-size: 0.8em;
+    color: #999;
+    padding: 2px 3px;
 }
 
 
 /* Adjustments for jQuery UI Styling */
 
 div.ganttview-block div.ui-resizable-handle.ui-resizable-s {
-	bottom: -0;
+    bottom: -0;
 }

--- a/jquery.ganttView.css
+++ b/jquery.ganttView.css
@@ -6,6 +6,7 @@ MIT License Applies
 
 div.ganttview-hzheader-month,
 div.ganttview-hzheader-day,
+div.ganttview-hzheader-chunk,
 div.ganttview-vtheader,
 div.ganttview-vtheader-item-name,
 div.ganttview-vtheader-series,
@@ -15,12 +16,14 @@ div.ganttview-grid-row-cell {
 }
 
 div.ganttview-hzheader-month,
-div.ganttview-hzheader-day {
+div.ganttview-hzheader-day,
+div.ganttview-hzheader-chunk {
 	text-align: center;
 }
 
 div.ganttview-grid-row-cell.last,
 div.ganttview-hzheader-day.last,
+div.ganttview-hzheader-chunk.last,
 div.ganttview-hzheader-month.last {
 	border-right: none;
 }

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -35,16 +35,16 @@ var dayInMS = 86400000;
 
     jQuery.fn.ganttView = function () {
         var args = Array.prototype.slice.call(arguments);
-        
+
         if (args.length == 1 && typeof(args[0]) == "object") {
             build.call(this, args[0]);
         }
-        
+
         if (args.length == 2 && typeof(args[0]) == "string") {
             handleMethod.call(this, args[0], args[1]);
         }
     };
-    
+
     function build(options) {
         var els = this;
         var defaults = {
@@ -68,7 +68,7 @@ var dayInMS = 86400000;
                 resizable: true
             }
         };
-        
+
         var opts = jQuery.extend(true, defaults, options);
 
         if (opts.data) {
@@ -76,7 +76,7 @@ var dayInMS = 86400000;
         } else if (opts.dataUrl) {
             jQuery.getJSON(opts.dataUrl, function (data) { opts.data = data; build(); });
         }
-        
+
         function build() {
             var minCells = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
             var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, opts.dateChunks, opts.buffer, minCells);
@@ -123,7 +123,7 @@ var dayInMS = 86400000;
                 "class": "ganttview-slide-container",
                 "css": { "width": opts.slideWidth + "px" }
             });
-            
+
             dates = getDates(opts.start, opts.end);
 
             addHzHeader(slideDiv, opts.start, dates, opts.dateChunks, opts.cellWidth);
@@ -133,7 +133,7 @@ var dayInMS = 86400000;
             div.append(slideDiv);
             applyLastClass(div.parent());
         }
-        
+
         var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
         // Creates a 3 dimensional array [year][month][day] of every day 
@@ -148,8 +148,8 @@ var dayInMS = 86400000;
                 var next = last.clone().addDays(1);
                 if (!dates[next.getFullYear()]) { dates[next.getFullYear()] = []; }
 
-                if (!dates[next.getFullYear()][next.getMonth()]) { 
-                    dates[next.getFullYear()][next.getMonth()] = []; 
+                if (!dates[next.getFullYear()][next.getMonth()]) {
+                    dates[next.getFullYear()][next.getMonth()] = [];
                 }
 
                 dates[next.getFullYear()][next.getMonth()].push(next);
@@ -163,13 +163,14 @@ var dayInMS = 86400000;
             var listId = {};
             var rowIdx = 1;
             var vthHeight = 41;
-            var headerDiv = jQuery("<div>", { 
+            var headerDiv = jQuery("<div>", {
                                                 "class": "ganttview-vtheader",
-                                                "css": { "margin-top": vthHeight + "px" } });
+                                                "css": { "margin-top": vthHeight + "px" }
+                                            });
             if(dateChunks > 1){
                 var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
                 itemDiv.append(jQuery("<div>", {
-                    "css": { 
+                    "css": {
                         "height": cellHeight*2/3 + "px",
                         "float":"right",
                         "padding-right":cellHeight/4+"px",
@@ -202,7 +203,7 @@ var dayInMS = 86400000;
                                 }
                                 seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(seriesNames.join(', ')));
                             }
-                            
+
                             itemDiv.append(seriesDiv);
                             headerDiv.append(itemDiv);
 
@@ -293,7 +294,7 @@ var dayInMS = 86400000;
                     }).append(monthNames[mCount] + "/" + y));
 
                     m.forEach(function (d) {
-                        daysDiv.append(jQuery("<div>", { 
+                        daysDiv.append(jQuery("<div>", {
                             "class": "ganttview-hzheader-day",
                             "css": { "width": (cellWidth*dateChunks - 1) + "px" }
                         }).append(d.getDate()));
@@ -308,7 +309,7 @@ var dayInMS = 86400000;
                                 var cellTime = -1, cellText = "";
 
                                 if (dateChunk == dateChunks - 1){ rightBorder = "1px solid #9999"; }
-                                
+
                                 if(dateChunk%2 == 0){
                                     if(timeMark%100 == 0){
                                         cellTime = timeMark;
@@ -317,7 +318,7 @@ var dayInMS = 86400000;
                                         var hourDecimal = timeMark%100;
                                         var minutes = Math.round(hourDecimal*3/5);
                                         if(minutes == 60){ minutes = 100; }
-                                        cellTime = timeMark - hourDecimal + minutes; 
+                                        cellTime = timeMark - hourDecimal + minutes;
                                     }
                                 }
 
@@ -356,14 +357,15 @@ var dayInMS = 86400000;
             var rowDiv = jQuery("<div>", { "class": "ganttview-grid-row" }).css('height', cellHeight);
 
             let isPriorToFreeze = true, isFreezeDate = false;
+
             if(freezeDate){
-                let freezeYear = freezeDate.getFullYear();
-                let freezeMonth = freezeDate.getMonth();
-                let freezeDay = freezeDate.getDate();
+                var freezeYear = freezeDate.getFullYear();
+                var freezeMonth = freezeDate.getMonth();
+                var freezeDay = freezeDate.getDate();
             }
 
             for (var y in dates) {
-                if(freezeDate && isPriorToFreeze && y > freezeYear){ 
+                if(freezeDate && isPriorToFreeze && y > freezeYear){
                     isPriorToFreeze = false;
                 }
 
@@ -380,7 +382,7 @@ var dayInMS = 86400000;
                             isPriorToFreeze = false;
                             isFreezeDate = true;
                         }
-                        
+
                         for (var dateChunk = 0; dateChunk < dateChunks; ++dateChunk){
                             var cellDiv = jQuery("<div>", { "class": "ganttview-grid-row-cell" });
                             if (isWeekendBool) { 
@@ -392,7 +394,7 @@ var dayInMS = 86400000;
                             else if (freezeDate && isFreezeDate) {
                                 let curTime = DateUtils.chunksToTime(dateChunk, dateChunks);
 
-                                if(curTime.hrs <= freezeDate.getHours() && curTime.mins <= freezeDate.getMinutes()){                                    
+                                if(curTime.hrs <= freezeDate.getHours() && curTime.mins <= freezeDate.getMinutes()){
                                     cellDiv.addClass("ganttview-frozen");
                                 }
                                 else{
@@ -456,9 +458,9 @@ var dayInMS = 86400000;
             var listId = {};
             var blockOffset = 60;
             if (dateChunks <= 1) { blockOffset = 40; }
-            var blocksDiv = jQuery("<div>", { 
+            var blocksDiv = jQuery("<div>", {
                                                 "class": "ganttview-blocks",
-                                                "css": { "margin-top": blockOffset + "px" } 
+                                                "css": { "margin-top": blockOffset + "px" }
                                             });
             for (var i = 0; i < data.length; i++)
             {
@@ -469,7 +471,7 @@ var dayInMS = 86400000;
                     {
                         if(typeof listId[ id ] === 'undefined')
                         {
-                            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));                         
+                            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
                             listId[ id ] = {index: rowIdx, cnt: 0};
                             rowIdx ++;
                         }
@@ -484,7 +486,6 @@ var dayInMS = 86400000;
                             }
                         }
                     }
-
                     else
                     {
                         blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
@@ -539,7 +540,7 @@ var dayInMS = 86400000;
             }
         }
 
-        function generateBlock(dataItem, rows, index, groupBySeries, start, dateChunks, cellWidth){ 
+        function generateBlock(dataItem, rows, index, groupBySeries, start, dateChunks, cellWidth){
             for (var j = 0; j < dataItem.series.length; j++)
             {
                 var series = dataItem.series[j];
@@ -558,10 +559,13 @@ var dayInMS = 86400000;
                       "top": 0
                     }
                 });
+
                 addBlockData(block, dataItem, series);
+
                 if (dataItem.series[j].color) {
                     block.css("background-color", dataItem.series[j].color);
                 }
+
                 block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size/dateChunks*24));
                 jQuery(rows[index]).append(block);
 
@@ -584,7 +588,7 @@ var dayInMS = 86400000;
             jQuery("div.ganttview-hzheader-days div.ganttview-hzheader-day:last-child", div).addClass("last");
             jQuery("div.ganttview-hzheader-months div.ganttview-hzheader-month:last-child", div).addClass("last");
         }
-            
+
         return {
             render: render
         };
@@ -595,16 +599,16 @@ var dayInMS = 86400000;
         function apply() {
             jQuery("div.ganttview-slide-container", div).scrollLeft(getScrollTo(opts.buffer, opts.dateChunks, opts.chunksToStartTime, opts.cellWidth, opts.cellBuffer));
 
-            if (opts.behavior.clickable) { 
-                bindBlockClick(div, opts.behavior.onClick); 
+            if (opts.behavior.clickable) {
+                bindBlockClick(div, opts.behavior.onClick);
             }
-            
+
             if (opts.behavior.resizable) {
-                bindBlockResize(div, opts.dateChunks, opts.cellBuffer, opts.cellWidth, opts.start, opts.freezeDate, opts.updateDependencies, opts.behavior.onResize); 
+                bindBlockResize(div, opts.dateChunks, opts.cellBuffer, opts.cellWidth, opts.start, opts.freezeDate, opts.updateDependencies, opts.behavior.onResize);
             }
-            
+
             if (opts.behavior.draggable) {
-                bindBlockDrag(div, opts.dateChunks, opts.cellBuffer, opts.cellWidth, opts.start, opts.freezeDate, opts.updateDependencies, opts.behavior.onDrag); 
+                bindBlockDrag(div, opts.dateChunks, opts.cellBuffer, opts.cellWidth, opts.start, opts.freezeDate, opts.updateDependencies, opts.behavior.onDrag);
             }
         }
 
@@ -613,7 +617,7 @@ var dayInMS = 86400000;
                 if (callback) { callback(jQuery(this).data("block-data")); }
             });
         }
-        
+
         function bindBlockResize(div, dateChunks, cellBuffer, cellWidth, startDate, freezeDate, updateDependencies, callback) {
             for(var block in jQuery("div.ganttview-block", div)){
                 if(block == parseInt(block)){
@@ -622,7 +626,7 @@ var dayInMS = 86400000;
 
                     if(!freezeDate || blockEnd > freezeDate){
                         thisBlock.resizable({
-                            grid: cellWidth, 
+                            grid: cellWidth,
                             handles: "e",
                             stop: function () {
                                 var block = jQuery(this);
@@ -636,7 +640,7 @@ var dayInMS = 86400000;
                 }
             }
         }
-        
+
         function bindBlockDrag(div, dateChunks, cellBuffer, cellWidth, startDate, freezeDate, updateDependencies, callback) {
             for(var block in jQuery("div.ganttview-block", div)){
                 if(block == parseInt(block)){
@@ -645,7 +649,7 @@ var dayInMS = 86400000;
 
                     if(!freezeDate || blockStart > freezeDate){
                         thisBlock.draggable({
-                            axis: "x", 
+                            axis: "x",
                             grid: [cellWidth, cellWidth],
                             stop: function () {
                                 var block = jQuery(this);
@@ -659,7 +663,7 @@ var dayInMS = 86400000;
                 }
             }
         }
-        
+
         function updateDataAndPosition(div, block, updatedData, dateChunks, cellBuffer, cellWidth, startDate, freezeDate, updateDependencies, isResize) {
             var parentChildren = block.parent().children();
             var childElementCount = parentChildren.length;
@@ -804,7 +808,7 @@ var dayInMS = 86400000;
         }
 
         return {
-            apply: apply    
+            apply: apply
         };
     }
 
@@ -813,8 +817,8 @@ var dayInMS = 86400000;
         contains: function (arr, obj) {
             var has = false;
 
-            for (var i = 0; i < arr.length; i++) { 
-                if (arr[i] == obj) { has = true; } 
+            for (var i = 0; i < arr.length; i++) {
+                if (arr[i] == obj) { has = true; }
             }
 
             return has;

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -17,35 +17,36 @@ groupById: boolean
 groupByIdDrawAllTitles: boolean
 dataUrl: string
 behavior: {
-	clickable: boolean,
-	draggable: boolean,
-	resizable: boolean,
-	onClick: function,
-	onDrag: function,
-	onResize: function
+    clickable: boolean,
+    draggable: boolean,
+    resizable: boolean,
+    onClick: function,
+    onDrag: function,
+    onResize: function
 }
 */
 
 (function (jQuery) {
-	
+
     jQuery.fn.ganttView = function () {
-    	
-    	var args = Array.prototype.slice.call(arguments);
-    	
-    	if (args.length == 1 && typeof(args[0]) == "object") {
-        	build.call(this, args[0]);
-    	}
-    	
-    	if (args.length == 2 && typeof(args[0]) == "string") {
-    		handleMethod.call(this, args[0], args[1]);
-    	}
+
+        var args = Array.prototype.slice.call(arguments);
+        
+        if (args.length == 1 && typeof(args[0]) == "object") {
+            build.call(this, args[0]);
+        }
+        
+        if (args.length == 2 && typeof(args[0]) == "string") {
+            handleMethod.call(this, args[0], args[1]);
+        }
     };
     
     function build(options) {
-    	
-    	var els = this;
+
+        var els = this;
         var defaults = {
             showWeekends: true,
+            dateChunks: 1, //default to day
             cellWidth: 21,
             cellHeight: 31,
             slideWidth: 400,
@@ -54,94 +55,120 @@ behavior: {
             groupByIdDrawAllTitles: false,
             vHeaderWidth: 100,
             behavior: {
-            	clickable: true,
-            	draggable: true,
-            	resizable: true
+                clickable: true,
+                draggable: true,
+                resizable: true
             }
         };
         
         var opts = jQuery.extend(true, defaults, options);
 
-				if (opts.data) {
-					build();
-				} else if (opts.dataUrl) {
-					jQuery.getJSON(opts.dataUrl, function (data) { opts.data = data; build(); });
-				}
-		
-				function build() {
-					
-					var minDays = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
-					var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, minDays);
-					opts.start = startEnd[0];
-					opts.end = startEnd[1];
-					
-			        els.each(function () {
-		
-			            var container = jQuery(this);
-			            var div = jQuery("<div>", { "class": "ganttview" });
-			            new Chart(div, opts).render();
-						container.append(div);
-						
-						var w = jQuery("div.ganttview-vtheader", container).outerWidth() +
-							jQuery("div.ganttview-slide-container", container).outerWidth();
-			            container.css("width", (w + 2) + "px");
-			            
-			            new Behavior(container, opts).apply();
-			        });
-				}
+        if (opts.data) {
+            console.log(opts.data);
+
+            opts.data.forEach(function (feature) {
+                if (feature.series) {
+                    let prevEnd;
+                    feature.series.forEach(function (item) {
+                        if (!prevEnd) {
+                            prevEnd = Date.parse(item.end);
+                        }
+                        else if (item.start < prevEnd) {
+                            var start = Date.parse(item.start);
+                            var end = Date.parse(item.end);
+
+                            let timeDiff = prevEnd - start;
+                            item.start = prevEnd;
+                            item.end = new Date(end.getTime() + timeDiff);
+
+                            prevEnd = end;
+                        }
+                    });
+                }
+            });
+
+            console.log(opts.data);
+
+            build();
+        } else if (opts.dataUrl) {
+            jQuery.getJSON(opts.dataUrl, function (data) { opts.data = data; build(); });
+        }
+        
+        function build() {
+
+            var minDays = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
+            var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, minDays);
+            opts.start = startEnd[0];
+            opts.end = startEnd[1];
+
+            els.each(function () {
+
+                var container = jQuery(this);
+                var div = jQuery("<div>", { "class": "ganttview" });
+                new Chart(div, opts).render();
+                container.append(div);
+
+                var w = jQuery("div.ganttview-vtheader", container).outerWidth() +
+                jQuery("div.ganttview-slide-container", container).outerWidth();
+                container.css("width", (w + 2) + "px");
+
+                new Behavior(container, opts).apply();
+            });
+        }
     }
 
-	function handleMethod(method, value) {
-		
-		if (method == "setSlideWidth") {
-			var div = $("div.ganttview", this);
-			div.each(function () {
-				var vtWidth = $("div.ganttview-vtheader", div).outerWidth();
-				$(div).width(vtWidth + value + 1);
-				$("div.ganttview-slide-container", this).width(value);
-			});
-		}
-	}
+    function handleMethod(method, value) {
 
-	var Chart = function(div, opts) {
-		
-		function render() {
-            
+        if (method == "setSlideWidth") {
+            var div = $("div.ganttview", this);
+            div.each(function () {
+                var vtWidth = $("div.ganttview-vtheader", div).outerWidth();
+                $(div).width(vtWidth + value + 1);
+                $("div.ganttview-slide-container", this).width(value);
+            });
+        }
+    }
+
+    var Chart = function(div, opts) {
+
+        function render() {
+
             addVtHeader(div, opts.data, opts.cellHeight, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
 
             var slideDiv = jQuery("<div>", {
                 "class": "ganttview-slide-container",
                 "css": { "width": opts.slideWidth + "px" }
             });
-			
+            
             dates = getDates(opts.start, opts.end);
-            addHzHeader(slideDiv, dates, opts.cellWidth);
-            addGrid(slideDiv, opts.data, dates, opts.cellWidth, opts.cellHeight, opts.showWeekends, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
+
+            addHzHeader(slideDiv, dates, opts.dateChunks, opts.cellWidth);
+            addGrid(slideDiv, opts.data, dates, opts.dateChunks, opts.cellWidth, opts.cellHeight, opts.showWeekends, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
             addBlockContainers(slideDiv, opts.data, opts.cellHeight, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
-            addBlocks(slideDiv, opts.data, opts.cellWidth, opts.cellHeight, opts.start, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
+            addBlocks(slideDiv, opts.data, opts.dateChunks, opts.cellWidth, opts.cellHeight, opts.start, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
             div.append(slideDiv);
             applyLastClass(div.parent());
-		}
-		
-		var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+        }
+        
+        var monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 
-		// Creates a 3 dimensional array [year][month][day] of every day 
-		// between the given start and end dates
+        // Creates a 3 dimensional array [year][month][day] of every day 
+        // between the given start and end dates
         function getDates(start, end) {
             var dates = [];
-						dates[start.getFullYear()] = [];
-						dates[start.getFullYear()][start.getMonth()] = [start]
-						var last = start;
-						while (last.compareTo(end) == -1) {
-							var next = last.clone().addDays(1);
-							if (!dates[next.getFullYear()]) { dates[next.getFullYear()] = []; }
-							if (!dates[next.getFullYear()][next.getMonth()]) { 
-								dates[next.getFullYear()][next.getMonth()] = []; 
-							}
-							dates[next.getFullYear()][next.getMonth()].push(next);
-							last = next;
-						}
-						return dates;
+            dates[start.getFullYear()] = [];
+            dates[start.getFullYear()][start.getMonth()] = [start]
+            var last = start;
+            while (last.compareTo(end) == -1) {
+                var next = last.clone().addDays(1);
+                if (!dates[next.getFullYear()]) { dates[next.getFullYear()] = []; }
+                if (!dates[next.getFullYear()][next.getMonth()]) { 
+                    dates[next.getFullYear()][next.getMonth()] = []; 
+                }
+                dates[next.getFullYear()][next.getMonth()].push(next);
+                last = next;
+            }
+            return dates;
         }
 
         function addVtHeader(div, data, cellHeight, groupBySeries, groupById, groupByIdDrawAllTitles) {
@@ -150,71 +177,71 @@ behavior: {
             var headerDiv = jQuery("<div>", { "class": "ganttview-vtheader" });
             for (var i = 0; i < data.length; i++)
             {
-            	if(groupBySeries)
-            	{
-            		var id = "" + data[i].id;
-	            	if(groupById && id.length > 0)
-	            	{
-	            		 if(typeof listId[ id ] == "undefined")
-	            		 {
-                            var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
-                            itemDiv.append(jQuery("<div>", {
-                                "class": "ganttview-vtheader-item-name",
-                                "css": { "height": cellHeight + "px" }
-                            }).append(data[i].name));
-                            var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
+                if(groupBySeries)
+                {
+                    var id = "" + data[i].id;
+                    if(groupById && id.length > 0)
+                    {
+                       if(typeof listId[ id ] == "undefined")
+                       {
+                        var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
+                        itemDiv.append(jQuery("<div>", {
+                            "class": "ganttview-vtheader-item-name",
+                            "css": { "height": cellHeight + "px" }
+                        }).append(data[i].name));
+                        var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
+                        var serieNames = new Array();
+                        for (var j = 0; j < data[i].series.length; j++)
+                        {
+                            serieNames.push(data[i].series[j].name);
+                        }
+                        seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
+                        itemDiv.append(seriesDiv);
+                        headerDiv.append(itemDiv);
+
+                        listId[ id ] = rowIdx;
+
+                        rowIdx ++;
+                    }
+                    else
+                    {
+                        if(groupByIdDrawAllTitles)
+                        {
+                            var localCellHeight = cellHeight;
+                            var itemDiv = headerDiv.children(':nth-child('+listId[ id ]+')');
+                            localCellHeight = cellHeight * (itemDiv.find('.ganttview-vtheader-item-name > br').length + 1);
+                            itemDiv.find('.ganttview-vtheader-item-name').append('<br />'+data[i].name).css('height', localCellHeight);
+
                             var serieNames = new Array();
                             for (var j = 0; j < data[i].series.length; j++)
                             {
                                 serieNames.push(data[i].series[j].name);
                             }
-                            seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
-                            itemDiv.append(seriesDiv);
-                            headerDiv.append(itemDiv);
-                            
-                            listId[ id ] = rowIdx;
-                            
-                            rowIdx ++;
-	            		 }
-                         else
-                         {
-                            if(groupByIdDrawAllTitles)
-                            {
-		            		 					var localCellHeight = cellHeight;
-	                            var itemDiv = headerDiv.children(':nth-child('+listId[ id ]+')');
-	            		 						localCellHeight = cellHeight * (itemDiv.find('.ganttview-vtheader-item-name > br').length + 1);
-                            	itemDiv.find('.ganttview-vtheader-item-name').append('<br />'+data[i].name).css('height', localCellHeight);
-	                             
-	                            var serieNames = new Array();
-	                            for (var j = 0; j < data[i].series.length; j++)
-	                            {
-	                                serieNames.push(data[i].series[j].name);
-	                            }
-	                            
-	                            itemDiv.find('.ganttview-vtheader-series-name').append('<br />'+serieNames.join(', ')).css('height', localCellHeight);
-	                          }
-                         }
-	              }
-	              else
-                  {
-	                var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
-	                itemDiv.append(jQuery("<div>", {
-	                    "class": "ganttview-vtheader-item-name",
-	                    "css": { "height": cellHeight + "px" }
-	                }).append(data[i].name));
-	                var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
-	                var serieNames = new Array();
-	                for (var j = 0; j < data[i].series.length; j++)
-	                {
-	                    serieNames.push(data[i].series[j].name);
-	                }
-	                seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
-	                itemDiv.append(seriesDiv);
-	                headerDiv.append(itemDiv);
-	              }
-              }
-              else
-              {
+
+                            itemDiv.find('.ganttview-vtheader-series-name').append('<br />'+serieNames.join(', ')).css('height', localCellHeight);
+                        }
+                    }
+                }
+                else
+                {
+                    var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
+                    itemDiv.append(jQuery("<div>", {
+                        "class": "ganttview-vtheader-item-name",
+                        "css": { "height": cellHeight + "px" }
+                    }).append(data[i].name));
+                    var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
+                    var serieNames = new Array();
+                    for (var j = 0; j < data[i].series.length; j++)
+                    {
+                        serieNames.push(data[i].series[j].name);
+                    }
+                    seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
+                    itemDiv.append(seriesDiv);
+                    headerDiv.append(itemDiv);
+                }
+            }
+            else
+            {
                 var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
                 itemDiv.append(jQuery("<div>", {
                     "class": "ganttview-vtheader-item-name",
@@ -224,46 +251,79 @@ behavior: {
                 for (var j = 0; j < data[i].series.length; j++)
                 {
                     seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" })
-										.append(data[i].series[j].name));
+                        .append(data[i].series[j].name));
                 }
                 itemDiv.append(seriesDiv);
                 headerDiv.append(itemDiv);
-              }
             }
-            div.append(headerDiv);
         }
+        div.append(headerDiv);
+    }
 
-        function addHzHeader(div, dates, cellWidth) {
-            var headerDiv = jQuery("<div>", { "class": "ganttview-hzheader" });
-            var monthsDiv = jQuery("<div>", { "class": "ganttview-hzheader-months" });
-            var daysDiv = jQuery("<div>", { "class": "ganttview-hzheader-days" });
-            var totalW = 0;
-            for (var y in dates) {
-                for (var m in dates[y]) {
-                    var w = dates[y][m].length * cellWidth;
-                    totalW = totalW + w;
-                    monthsDiv.append(jQuery("<div>", {
-                        "class": "ganttview-hzheader-month",
-                        "css": { "width": (w - 1) + "px" }
-                    }).append(monthNames[m] + "/" + y));
-                    for (var d in dates[y][m]) {
-                        daysDiv.append(jQuery("<div>", { "class": "ganttview-hzheader-day" })
-                            .append(dates[y][m][d].getDate()));
+    function addHzHeader(div, dates, dateChunks, cellWidth) {
+        var headerDiv = jQuery("<div>", { "class": "ganttview-hzheader" });
+        var monthsDiv = jQuery("<div>", { "class": "ganttview-hzheader-months" });
+        var daysDiv = jQuery("<div>", { "class": "ganttview-hzheader-days" });
+        var chunksDiv = jQuery("<div>", { "class": "ganttview-hzheader-chunks" });
+        var totalW = 0;
+
+        for (var y in dates) {
+            mCount = 0;
+            dates[y].forEach(function (m) {
+                var w = m.length * cellWidth * dateChunks;
+                totalW = totalW + w;
+                monthsDiv.append(jQuery("<div>", {
+                    "class": "ganttview-hzheader-month",
+                    "css": { "width": (w - 1) + "px" }
+                }).append(monthNames[mCount] + "/" + y));
+
+                dCount = 1;
+
+                m.forEach(function (d) {
+                    daysDiv.append(jQuery("<div>", { 
+                        "class": "ganttview-hzheader-day",
+                        "css": { "width": (cellWidth*dateChunks - 1) + "px" }
+                    }).append(dCount));
+
+                    if(dateChunk > 1){
+                        let hourMark = Math.parseInt(24/dateChunk);
+
+                        for(var dateChunk=0; dateChunk < dateChunks; ++dateChunk){
+                            if (dateChunk%hourMark != 0){
+                                chunksDiv.append(jQuery("<div>", {
+                                    "class": "ganttview-hzheader-chunk",
+                                    "css": { "width": (cellWidth) + "px" }
+                                }) )
+                            }
+                            else {
+                                chunksDiv.append(jQuery("<div>", {
+                                    "class": "ganttview-hzheader-chunk",
+                                    "css": { "width": (cellWidth) + "px" }
+                                }).append(dateChunk));
+                            }
+                        }
                     }
-                }
-            }
-            monthsDiv.css("width", totalW + "px");
-            daysDiv.css("width", totalW + "px");
-            headerDiv.append(monthsDiv).append(daysDiv);
-            div.append(headerDiv);
+
+                    ++dCount;
+                })
+                ++mCount;
+            })
         }
 
-        function addGrid(div, data, dates, cellWidth, cellHeight, showWeekends, groupBySeries, groupById, groupByIdDrawAllTitles) {
-            var gridDiv = jQuery("<div>", { "class": "ganttview-grid" });
-            var rowDiv = jQuery("<div>", { "class": "ganttview-grid-row" }).css('height', cellHeight);
-            for (var y in dates) {
-                for (var m in dates[y]) {
-                    for (var d in dates[y][m]) {
+        monthsDiv.css("width", totalW + "px");
+        daysDiv.css("width", totalW + "px");
+        chunksDiv.css("width", totalW + "px");
+        headerDiv.append(monthsDiv).append(daysDiv).append(chunksDiv);
+        div.append(headerDiv);
+    }
+
+    function addGrid(div, data, dates, dateChunks, cellWidth, cellHeight, showWeekends, groupBySeries, groupById, groupByIdDrawAllTitles) {
+        var gridDiv = jQuery("<div>", { "class": "ganttview-grid" });
+        var rowDiv = jQuery("<div>", { "class": "ganttview-grid-row" }).css('height', cellHeight);
+        for (var y in dates) {
+            for (var m in dates[y]) {
+                for (var d in dates[y][m]) {
+                    for (var dateChunk = 0; dateChunk < dateChunks; ++dateChunk){
                         var cellDiv = jQuery("<div>", { "class": "ganttview-grid-row-cell" });
                         if (DateUtils.isWeekend(dates[y][m][d]) && showWeekends) { 
                             cellDiv.addClass("ganttview-weekend"); 
@@ -272,227 +332,228 @@ behavior: {
                     }
                 }
             }
-            
-            var rowIdx = 1;
-            var listId = {};
-            var w = jQuery("div.ganttview-grid-row-cell", rowDiv).length * cellWidth;
-            rowDiv.css("width", w + "px");
-            gridDiv.css("width", w + "px");
-            for (var i = 0; i < data.length; i++)
-            {
-            	if(groupBySeries)
-            	{
-            		var id = "" + data[i].id;
-	            	if(groupById && id.length > 0)
-	            	{
-	            		 if(typeof listId[ id ] === 'undefined')
-	            		 {
-		                 gridDiv.append(rowDiv.clone());
-                            
-                     listId[ id ] = {index: rowIdx, cnt: 0};
-                    
-                     rowIdx ++;
-	            		 }
-	            		 else
-	            		 {
-	            		   if(groupByIdDrawAllTitles)
-	            		 	 {
-		            			 listId[ id ].cnt ++;
-	                     var itemRowDiv = gridDiv.children(':nth-child('+listId[ id ].index+')');
-	                     itemRowDiv.css('height', listId[ id ].cnt * cellHeight);
-	                   }
-	            		 }
-	              }
-	              else
-	            	{
-	                 gridDiv.append(rowDiv.clone());
-	              }
-              }
-              else
-              {
-                for (var j = 0; j < data[i].series.length; j++)
-                {
-                    gridDiv.append(rowDiv.clone());
-                }
-              }
-            }
-            div.append(gridDiv);
         }
 
-        function addBlockContainers(div, data, cellHeight, groupBySeries, groupById, groupByIdDrawAllTitles) {
-            var rowIdx = 1;
-            var listId = {};
-            var blocksDiv = jQuery("<div>", { "class": "ganttview-blocks" });
-            for (var i = 0; i < data.length; i++)
+        var rowIdx = 1;
+        var listId = {};
+        var w = jQuery("div.ganttview-grid-row-cell", rowDiv).length * cellWidth;
+        rowDiv.css("width", w + "px");
+        gridDiv.css("width", w + "px");
+        for (var i = 0; i < data.length; i++)
+        {
+            if(groupBySeries)
             {
-            	if(groupBySeries)
-            	{
-            		var id = "" + data[i].id;
-	            	if(groupById && id.length > 0)
-	            	{
-	            		 if(typeof listId[ id ] === 'undefined')
-	            		 {
-                            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
-		                 
-                     listId[ id ] = {index: rowIdx, cnt: 0};
-                    
-                     rowIdx ++;
-	            		 }
-	            		 else
-	            		 {
-	            		   if(groupByIdDrawAllTitles)
-	            		 	 {
-		            			 listId[ id ].cnt ++;
-	                     var itemBlockDiv = blocksDiv.children(':nth-child('+listId[ id ].index+')');
-	                     itemBlockDiv.css('height', listId[ id ].cnt * cellHeight - 3);
-	                   }
-	            		 }
-	              }
-	              else
-                  {
-                    blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
-	              }
-              }
-              else
-              {
-                for (var j = 0; j < data[i].series.length; j++)
+                var id = "" + data[i].id;
+                if(groupById && id.length > 0)
                 {
-                    blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
+                   if(typeof listId[ id ] === 'undefined')
+                   {
+                       gridDiv.append(rowDiv.clone());
+
+                       listId[ id ] = {index: rowIdx, cnt: 0};
+
+                       rowIdx ++;
+                   }
+                   else
+                   {
+                     if(groupByIdDrawAllTitles)
+                     {
+                       listId[ id ].cnt ++;
+                       var itemRowDiv = gridDiv.children(':nth-child('+listId[ id ].index+')');
+                       itemRowDiv.css('height', listId[ id ].cnt * cellHeight);
+                   }
+               }
+           }
+           else
+           {
+               gridDiv.append(rowDiv.clone());
+           }
+       }
+       else
+       {
+        for (var j = 0; j < data[i].series.length; j++)
+        {
+            gridDiv.append(rowDiv.clone());
+        }
+    }
+}
+div.append(gridDiv);
+}
+
+function addBlockContainers(div, data, cellHeight, groupBySeries, groupById, groupByIdDrawAllTitles) {
+    var rowIdx = 1;
+    var listId = {};
+    var blocksDiv = jQuery("<div>", { "class": "ganttview-blocks" });
+    for (var i = 0; i < data.length; i++)
+    {
+        if(groupBySeries)
+        {
+            var id = "" + data[i].id;
+            if(groupById && id.length > 0)
+            {
+                if(typeof listId[ id ] === 'undefined')
+                {
+                    blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));                         
+                    listId[ id ] = {index: rowIdx, cnt: 0};
+                    rowIdx ++;
                 }
-              }
+
+                else
+                {
+                 if(groupByIdDrawAllTitles)
+                 {
+                    listId[ id ].cnt ++;
+                    var itemBlockDiv = blocksDiv.children(':nth-child('+listId[ id ].index+')');
+                    itemBlockDiv.css('height', listId[ id ].cnt * cellHeight - 3);
+                }
             }
-            div.append(blocksDiv);
         }
 
-        function addBlocks(div, data, cellWidth, cellHeight, start, groupBySeries, groupById, groupByIdDrawAllTitles) {
-            var listId = {};
-            var rows = jQuery("div.ganttview-blocks div.ganttview-block-container", div);
-            var rowIdx = 0;
-            
-            for (var i = 0; i < data.length; i++)
+        else
+        {
+            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
+        }
+    }
+    else
+    {
+        for (var j = 0; j < data[i].series.length; j++)
+        {
+            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
+        }
+    }
+}
+div.append(blocksDiv);
+}
+
+function addBlocks(div, data, dateChunks, cellWidth, cellHeight, start, groupBySeries, groupById, groupByIdDrawAllTitles) {
+    var listId = {};
+    var rows = jQuery("div.ganttview-blocks div.ganttview-block-container", div);
+    var rowIdx = 0;
+
+    for (var i = 0; i < data.length; i++)
+    {
+        if(groupBySeries)
+        {
+            var id = "" + data[i].id;
+            if(groupById && id.length > 0)
             {
-            	if(groupBySeries)
-            	{
-            		var id = "" + data[i].id;
-	            	if(groupById && id.length > 0)
-	            	{
-	            		 if(typeof listId[ id ] == "undefined")
-	            		 {
-			                for (var j = 0; j < data[i].series.length; j++)
-			                {
-			                    var series = data[i].series[j];
-			                    var size = DateUtils.daysBetween(series.start, series.end) + 1;
-                                var offset = DateUtils.daysBetween(start, series.start);
-                                var block = jQuery("<div>", {
-				                      "class": "ganttview-block",
-				                      "title": series.name + ", " + size + " days",
-				                      "css": {
-				                          "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
-				                          "width": ((size * cellWidth) - 9) + "px",
-				                          "margin-left": ((offset * cellWidth) + 3) + "px",
-				                          "top": 0
-				                      }
-                                });
-			                    addBlockData(block, data[i], series);
-			                    if (data[i].series[j].color) {
-			                        block.css("background-color", data[i].series[j].color);
-			                    }
-			                    block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-		               		   jQuery(rows[rowIdx]).append(block);
-				              }
-		                 
-                              listId[ id ] = rowIdx;
-				              
-                              rowIdx = rowIdx + 1;
-	            		 }
-	            		 else
-	            		 {
-			                for (var j = 0; j < data[i].series.length; j++)
-			                {
-			                    var series = data[i].series[j];
-			                    var size = DateUtils.daysBetween(series.start, series.end) + 1;
-                                var offset = DateUtils.daysBetween(start, series.start);
-                                var block = jQuery("<div>", {
-				                      "class": "ganttview-block",
-				                      "title": series.name + ", " + size + " days",
-				                      "css": {
-				                          "height": (parseInt(jQuery(rows[ listId[ id ] ]).css('height'), 10) - 4) + "px",
-				                          "width": ((size * cellWidth) - 9) + "px",
-				                          "margin-left": ((offset * cellWidth) + 3) + "px",
-				                          "top": 0
-				                      }
-                                });
-			                    addBlockData(block, data[i], series);
-			                    if (data[i].series[j].color) {
-			                        block.css("background-color", data[i].series[j].color);
-			                    }
-			                    block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-		               		   jQuery(rows[ listId[ id ] ]).append(block);
-				              }
-	            		 }
-	              }
-	              else
-                  {
-	                for (var j = 0; j < data[i].series.length; j++)
-	                {
-	                    var series = data[i].series[j];
-	                    var size = DateUtils.daysBetween(series.start, series.end) + 1;
-                        var offset = DateUtils.daysBetween(start, series.start);
-                        var block = jQuery("<div>", {
-		                      "class": "ganttview-block",
-		                      "title": series.name + ", " + size + " days",
-		                      "css": {
-				                      "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
-		                          "width": ((size * cellWidth) - 9) + "px",
-		                          "margin-left": ((offset * cellWidth) + 3) + "px",
-                                  "top": 0,
-		                      }
-		                  });
-	                    addBlockData(block, data[i], series);
-	                    if (data[i].series[j].color) {
-	                        block.css("background-color", data[i].series[j].color);
-	                    }
-	                    block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-               		   jQuery(rows[rowIdx]).append(block);
-		              }
-                      rowIdx = rowIdx + 1;
-	              }
-              }
-              else
-              {
+               if(typeof listId[ id ] == "undefined")
+               {
                 for (var j = 0; j < data[i].series.length; j++)
                 {
                     var series = data[i].series[j];
-                    var size = DateUtils.daysBetween(series.start, series.end) + 1;
-                    var offset = DateUtils.daysBetween(start, series.start);
+                    var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
+                    var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
                     var block = jQuery("<div>", {
-                        "class": "ganttview-block",
-                        "title": series.name + ", " + size + " days",
-                        "css": {
-				                    "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
-                            "width": ((size * cellWidth) - 9) + "px",
-                            "margin-left": ((offset * cellWidth) + 3) + "px",
-                            "top": "0px"
-                        }
-                    });
+                      "class": "ganttview-block",
+                      "title": series.name + ", " + size + " hrs",
+                      "css": {
+                          "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
+                          "width": ((size * cellWidth) - 9) + "px",
+                          "margin-left": ((offset * cellWidth) + 3) + "px",
+                          "top": 0
+                      }
+                  });
                     addBlockData(block, data[i], series);
                     if (data[i].series[j].color) {
                         block.css("background-color", data[i].series[j].color);
                     }
                     block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
                     jQuery(rows[rowIdx]).append(block);
-                    rowIdx = rowIdx + 1;
                 }
-              }
+
+                listId[ id ] = rowIdx;
+
+                rowIdx = rowIdx + 1;
+            }
+            else
+            {
+                for (var j = 0; j < data[i].series.length; j++)
+                {
+                    var series = data[i].series[j];
+                    var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
+                    var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
+                    var block = jQuery("<div>", {
+                      "class": "ganttview-block",
+                      "title": series.name + ", " + size + " days",
+                      "css": {
+                          "height": (parseInt(jQuery(rows[ listId[ id ] ]).css('height'), 10) - 4) + "px",
+                          "width": ((size * cellWidth) - 9) + "px",
+                          "margin-left": ((offset * cellWidth) + 3) + "px",
+                          "top": 0
+                      }
+                  });
+                    addBlockData(block, data[i], series);
+                    if (data[i].series[j].color) {
+                        block.css("background-color", data[i].series[j].color);
+                    }
+                    block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+                    jQuery(rows[ listId[ id ] ]).append(block);
+                }
             }
         }
-        
-        function addBlockData(block, data, series) {
-        	// This allows custom attributes to be added to the series data objects
-        	// and makes them available to the 'data' argument of click, resize, and drag handlers
-        	var blockData = { id: data.id, name: data.name };
-        	jQuery.extend(blockData, series);
-        	block.data("block-data", blockData);
+        else
+        {
+            for (var j = 0; j < data[i].series.length; j++)
+            {
+                var series = data[i].series[j];
+                var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
+                var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
+                var block = jQuery("<div>", {
+                  "class": "ganttview-block",
+                  "title": series.name + ", " + size + " days",
+                  "css": {
+                      "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
+                      "width": ((size * cellWidth) - 9) + "px",
+                      "margin-left": ((offset * cellWidth) + 3) + "px",
+                      "top": 0,
+                  }
+              });
+                addBlockData(block, data[i], series);
+                if (data[i].series[j].color) {
+                    block.css("background-color", data[i].series[j].color);
+                }
+                block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+                jQuery(rows[rowIdx]).append(block);
+            }
+            rowIdx = rowIdx + 1;
+        }
+    }
+    else
+    {
+        for (var j = 0; j < data[i].series.length; j++)
+        {
+            var series = data[i].series[j];
+            var size = DateUtils.daysBetween(series.start, series.end) + 1;
+            var offset = DateUtils.daysBetween(start, series.start);
+            var block = jQuery("<div>", {
+                "class": "ganttview-block",
+                "title": series.name + ", " + size + " days",
+                "css": {
+                    "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
+                    "width": ((size * cellWidth) - 9) + "px",
+                    "margin-left": ((offset * cellWidth) + 3) + "px",
+                    "top": "0px"
+                }
+            });
+            addBlockData(block, data[i], series);
+            if (data[i].series[j].color) {
+                block.css("background-color", data[i].series[j].color);
+            }
+            block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+            jQuery(rows[rowIdx]).append(block);
+            rowIdx = rowIdx + 1;
+        }
+    }
+}
+}
+
+function addBlockData(block, data, series) {
+            // This allows custom attributes to be added to the series data objects
+            // and makes them available to the 'data' argument of click, resize, and drag handlers
+            var blockData = { id: data.id, name: data.name };
+            jQuery.extend(blockData, series);
+            block.data("block-data", blockData);
         }
 
         function applyLastClass(div) {
@@ -500,28 +561,28 @@ behavior: {
             jQuery("div.ganttview-hzheader-days div.ganttview-hzheader-day:last-child", div).addClass("last");
             jQuery("div.ganttview-hzheader-months div.ganttview-hzheader-month:last-child", div).addClass("last");
         }
-		
-		return {
-			render: render
-		};
-	}
+        
+        return {
+            render: render
+        };
+    }
 
-	var Behavior = function (div, opts) {
-		
-		function apply() {
-			
-			if (opts.behavior.clickable) { 
-            	bindBlockClick(div, opts.behavior.onClick); 
-        	}
-        	
+    var Behavior = function (div, opts) {
+
+        function apply() {
+
+            if (opts.behavior.clickable) { 
+                bindBlockClick(div, opts.behavior.onClick); 
+            }
+            
             if (opts.behavior.resizable) { 
-            	bindBlockResize(div, opts.cellWidth, opts.start, opts.behavior.onResize); 
-        	}
+                bindBlockResize(div, opts.dateChunks, opts.cellWidth, opts.start, opts.behavior.onResize); 
+            }
             
             if (opts.behavior.draggable) { 
-            	bindBlockDrag(div, opts.cellWidth, opts.start, opts.behavior.onDrag); 
-        	}
-		}
+                bindBlockDrag(div, opts.dateChunks, opts.cellWidth, opts.start, opts.behavior.onDrag); 
+            }
+        }
 
         function bindBlockClick(div, callback) {
             jQuery("div.ganttview-block", div).live("click", function () {
@@ -529,93 +590,96 @@ behavior: {
             });
         }
         
-        function bindBlockResize(div, cellWidth, startDate, callback) {
-        	jQuery("div.ganttview-block", div).resizable({
-        		grid: cellWidth, 
-        		handles: "e,w",
-        		stop: function () {
-        			var block = jQuery(this);
-        			updateDataAndPosition(div, block, cellWidth, startDate);
-        			if (callback) { callback(block.data("block-data")); }
-        		}
-        	});
-        }
-        
-        function bindBlockDrag(div, cellWidth, startDate, callback) {
-        	jQuery("div.ganttview-block", div).draggable({
-        		axis: "x", 
-        		grid: [cellWidth, cellWidth],
-        		stop: function () {
-        			var block = jQuery(this);
-        			updateDataAndPosition(div, block, cellWidth, startDate);
-        			if (callback) { callback(block.data("block-data")); }
-        		}
-        	});
-        }
-        
-        function updateDataAndPosition(div, block, cellWidth, startDate) {
-        	var container = jQuery("div.ganttview-slide-container", div);
-        	var scroll = container.scrollLeft();
-					var offset = block.offset().left - container.offset().left - 1 + scroll;
-					
-					// Set new start date
-					var daysFromStart = Math.round(offset / cellWidth);
-					var newStart = startDate.clone().addDays(daysFromStart);
-					block.data("block-data").start = newStart;
-		
-					// Set new end date
-                    var width = block.outerWidth();
-					var numberOfDays = Math.round(width / cellWidth) - 1;
-					block.data("block-data").end = newStart.clone().addDays(numberOfDays);
-					jQuery("div.ganttview-block-text", block).text(numberOfDays + 1);
-					
-					// Remove top and left properties to avoid incorrect block positioning,
-        	// set position to relative to keep blocks relative to scrollbar when scrolling
-					block.css("top", "0").css("left", "")
-						.css("position", "absolute").css("margin-left", offset + "px");
-       	}
-        
-        return {
-        	apply: apply	
-        };
-	}
-
-    var ArrayUtils = {
-	
-        contains: function (arr, obj) {
-            var has = false;
-            for (var i = 0; i < arr.length; i++) { if (arr[i] == obj) { has = true; } }
-            return has;
-        }
-    };
-
-    var DateUtils = {
-    	
-        daysBetween: function (start, end) {
-            if (!start || !end) { return 0; }
-            start = Date.parse(start); end = Date.parse(end);
-            if (start.getYear() == 1901 || end.getYear() == 8099) { return 0; }
-            var count = 0, date = start.clone();
-            while (date.compareTo(end) == -1) { count = count + 1; date.addDays(1); }
-            return count;
-        },
-        
-        isWeekend: function (date) {
-            return date.getDay() % 6 == 0;
-        },
-
-        getBoundaryDatesFromData: function (data, minDays) {
-            var minStart = new Date(); maxEnd = new Date();
-            for (var i = 0; i < data.length; i++) {
-                for (var j = 0; j < data[i].series.length; j++) {
-                    var start = Date.parse(data[i].series[j].start);
-                    var end = Date.parse(data[i].series[j].end)
-                    if (i == 0 && j == 0) { minStart = start; maxEnd = end; }
-                    if (minStart.compareTo(start) == 1) { minStart = start; }
-                    if (maxEnd.compareTo(end) == -1) { maxEnd = end; }
+        function bindBlockResize(div, dateChunks, cellWidth, startDate, callback) {
+            jQuery("div.ganttview-block", div).resizable({
+                grid: cellWidth, 
+                handles: "e,w",
+                stop: function () {
+                    var block = jQuery(this);
+                    updateDataAndPosition(div, block, dateChunks, cellWidth, startDate);
+                    if (callback) { callback(block.data("block-data")); }
                 }
+            });
+        }
+        
+        function bindBlockDrag(div, dateChunks, cellWidth, startDate, callback) {
+            jQuery("div.ganttview-block", div).draggable({
+                axis: "x", 
+                grid: [cellWidth, cellWidth],
+                stop: function () {
+                    var block = jQuery(this);
+                    updateDataAndPosition(div, block, dateChunks, cellWidth, startDate);
+                    if (callback) { callback(block.data("block-data")); }
+                }
+            });
+        }
+        
+        function updateDataAndPosition(div, block, dateChunks, cellWidth, startDate) {
+            var container = jQuery("div.ganttview-slide-container", div);
+            var scroll = container.scrollLeft();
+            var offset = block.offset().left - container.offset().left - 1 + scroll;
+
+                    // Set new start date
+                    var dayInMS = 86400000;
+                    var chunkInMS = dayInMS/dateChunks;
+
+                    var chunksFromStart = Math.round(offset / cellWidth);
+                    var newStart = new Date(startDate.getTime() + (chunksFromStart*chunkInMS));
+                    block.data("block-data").start = newStart;
+
+                    // Set new end date
+                    var width = block.outerWidth();
+                    var chunksFromStart = parseInt(width / cellWidth) + 1;
+                    block.data("block-data").end = new Date(newStart.clone().getTime() + (chunksFromStart*chunkInMS));
+                    jQuery("div.ganttview-block-text", block).text(chunksFromStart + 1);
+                    
+                    // Remove top and left properties to avoid incorrect block positioning,
+                    // set position to relative to keep blocks relative to scrollbar when scrolling
+                    block.css("top", "0").css("left", "")
+                    .css("position", "absolute").css("margin-left", offset + "px");
+                }
+
+                return {
+                    apply: apply    
+                };
             }
-            
+
+            var ArrayUtils = {
+
+                contains: function (arr, obj) {
+                    var has = false;
+                    for (var i = 0; i < arr.length; i++) { if (arr[i] == obj) { has = true; } }
+                        return has;
+                }
+            };
+
+            var DateUtils = {
+
+                daysBetween: function (start, end) {
+                    if (!start || !end) { return 0; }
+                    start = Date.parse(start); end = Date.parse(end);
+                    if (start.getYear() == 1901 || end.getYear() == 8099) { return 0; }
+                    var count = 0, date = start.clone();
+                    while (date.compareTo(end) == -1) { count = count + 1; date.addDays(1); }
+                    return count;
+                },
+
+                isWeekend: function (date) {
+                    return date.getDay() % 6 == 0;
+                },
+
+                getBoundaryDatesFromData: function (data, minDays) {
+                    var minStart = new Date(); maxEnd = new Date();
+                    for (var i = 0; i < data.length; i++) {
+                        for (var j = 0; j < data[i].series.length; j++) {
+                            var start = Date.parse(data[i].series[j].start);
+                            var end = Date.parse(data[i].series[j].end)
+                            if (i == 0 && j == 0) { minStart = start; maxEnd = end; }
+                            if (minStart.compareTo(start) == 1) { minStart = start; }
+                            if (maxEnd.compareTo(end) == -1) { maxEnd = end; }
+                        }
+                    }
+
             // Insure that the width of the chart is at least the slide width to avoid empty
             // whitespace to the right of the grid
             if (DateUtils.daysBetween(minStart, maxEnd) < minDays) {

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -29,7 +29,6 @@ behavior: {
 (function (jQuery) {
 
     jQuery.fn.ganttView = function () {
-
         var args = Array.prototype.slice.call(arguments);
         
         if (args.length == 1 && typeof(args[0]) == "object") {
@@ -42,7 +41,6 @@ behavior: {
     };
     
     function build(options) {
-
         var els = this;
         var defaults = {
             showWeekends: true,
@@ -76,8 +74,8 @@ behavior: {
                         else if (item.start < prevEnd) {
                             var start = Date.parse(item.start);
                             var end = Date.parse(item.end);
+                            var timeDiff = prevEnd - start;
 
-                            let timeDiff = prevEnd - start;
                             item.start = prevEnd;
                             item.end = new Date(end.getTime() + timeDiff);
 
@@ -87,29 +85,28 @@ behavior: {
                 }
             });
 
-            console.log(opts.data);
-
             build();
         } else if (opts.dataUrl) {
             jQuery.getJSON(opts.dataUrl, function (data) { opts.data = data; build(); });
         }
         
         function build() {
-
             var minDays = Math.floor((opts.slideWidth / opts.cellWidth)  + 5);
             var startEnd = DateUtils.getBoundaryDatesFromData(opts.data, minDays);
             opts.start = startEnd[0];
             opts.end = startEnd[1];
 
             els.each(function () {
-
                 var container = jQuery(this);
                 var div = jQuery("<div>", { "class": "ganttview" });
+
                 new Chart(div, opts).render();
+
                 container.append(div);
 
                 var w = jQuery("div.ganttview-vtheader", container).outerWidth() +
-                jQuery("div.ganttview-slide-container", container).outerWidth();
+                        jQuery("div.ganttview-slide-container", container).outerWidth();
+
                 container.css("width", (w + 2) + "px");
 
                 new Behavior(container, opts).apply();
@@ -118,7 +115,6 @@ behavior: {
     }
 
     function handleMethod(method, value) {
-
         if (method == "setSlideWidth") {
             var div = $("div.ganttview", this);
             div.each(function () {
@@ -159,15 +155,19 @@ behavior: {
             dates[start.getFullYear()] = [];
             dates[start.getFullYear()][start.getMonth()] = [start]
             var last = start;
+
             while (last.compareTo(end) == -1) {
                 var next = last.clone().addDays(1);
                 if (!dates[next.getFullYear()]) { dates[next.getFullYear()] = []; }
+
                 if (!dates[next.getFullYear()][next.getMonth()]) { 
                     dates[next.getFullYear()][next.getMonth()] = []; 
                 }
+
                 dates[next.getFullYear()][next.getMonth()].push(next);
                 last = next;
             }
+
             return dates;
         }
 
@@ -184,6 +184,46 @@ behavior: {
                     {
                        if(typeof listId[ id ] == "undefined")
                        {
+                            var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
+                            itemDiv.append(jQuery("<div>", {
+                                "class": "ganttview-vtheader-item-name",
+                                "css": { "height": cellHeight + "px" }
+                            }).append(data[i].name));
+                            var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
+                            var serieNames = new Array();
+                            for (var j = 0; j < data[i].series.length; j++)
+                            {
+                                serieNames.push(data[i].series[j].name);
+                            }
+                            seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
+                            itemDiv.append(seriesDiv);
+                            headerDiv.append(itemDiv);
+
+                            listId[ id ] = rowIdx;
+
+                            rowIdx ++;
+                        }
+                        else
+                        {
+                            if(groupByIdDrawAllTitles)
+                            {
+                                var localCellHeight = cellHeight;
+                                var itemDiv = headerDiv.children(':nth-child('+listId[ id ]+')');
+                                localCellHeight = cellHeight * (itemDiv.find('.ganttview-vtheader-item-name > br').length + 1);
+                                itemDiv.find('.ganttview-vtheader-item-name').append('<br />'+data[i].name).css('height', localCellHeight);
+
+                                var serieNames = new Array();
+                                for (var j = 0; j < data[i].series.length; j++)
+                                {
+                                    serieNames.push(data[i].series[j].name);
+                                }
+
+                                itemDiv.find('.ganttview-vtheader-series-name').append('<br />'+serieNames.join(', ')).css('height', localCellHeight);
+                            }
+                        }
+                    }
+                    else
+                    {
                         var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
                         itemDiv.append(jQuery("<div>", {
                             "class": "ganttview-vtheader-item-name",
@@ -198,28 +238,6 @@ behavior: {
                         seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
                         itemDiv.append(seriesDiv);
                         headerDiv.append(itemDiv);
-
-                        listId[ id ] = rowIdx;
-
-                        rowIdx ++;
-                    }
-                    else
-                    {
-                        if(groupByIdDrawAllTitles)
-                        {
-                            var localCellHeight = cellHeight;
-                            var itemDiv = headerDiv.children(':nth-child('+listId[ id ]+')');
-                            localCellHeight = cellHeight * (itemDiv.find('.ganttview-vtheader-item-name > br').length + 1);
-                            itemDiv.find('.ganttview-vtheader-item-name').append('<br />'+data[i].name).css('height', localCellHeight);
-
-                            var serieNames = new Array();
-                            for (var j = 0; j < data[i].series.length; j++)
-                            {
-                                serieNames.push(data[i].series[j].name);
-                            }
-
-                            itemDiv.find('.ganttview-vtheader-series-name').append('<br />'+serieNames.join(', ')).css('height', localCellHeight);
-                        }
                     }
                 }
                 else
@@ -227,328 +245,310 @@ behavior: {
                     var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
                     itemDiv.append(jQuery("<div>", {
                         "class": "ganttview-vtheader-item-name",
-                        "css": { "height": cellHeight + "px" }
+                        "css": { "height": (data[i].series.length * cellHeight) + "px" }
                     }).append(data[i].name));
                     var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
-                    var serieNames = new Array();
                     for (var j = 0; j < data[i].series.length; j++)
                     {
-                        serieNames.push(data[i].series[j].name);
+                        seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" })
+                            .append(data[i].series[j].name));
                     }
-                    seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
                     itemDiv.append(seriesDiv);
                     headerDiv.append(itemDiv);
                 }
             }
-            else
-            {
-                var itemDiv = jQuery("<div>", { "class": "ganttview-vtheader-item" });
-                itemDiv.append(jQuery("<div>", {
-                    "class": "ganttview-vtheader-item-name",
-                    "css": { "height": (data[i].series.length * cellHeight) + "px" }
-                }).append(data[i].name));
-                var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
-                for (var j = 0; j < data[i].series.length; j++)
-                {
-                    seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" })
-                        .append(data[i].series[j].name));
-                }
-                itemDiv.append(seriesDiv);
-                headerDiv.append(itemDiv);
-            }
+            div.append(headerDiv);
         }
-        div.append(headerDiv);
-    }
 
-    function addHzHeader(div, dates, dateChunks, cellWidth) {
-        var headerDiv = jQuery("<div>", { "class": "ganttview-hzheader" });
-        var monthsDiv = jQuery("<div>", { "class": "ganttview-hzheader-months" });
-        var daysDiv = jQuery("<div>", { "class": "ganttview-hzheader-days" });
-        var chunksDiv = jQuery("<div>", { "class": "ganttview-hzheader-chunks" });
-        var totalW = 0;
+        function addHzHeader(div, dates, dateChunks, cellWidth) {
+            var headerDiv = jQuery("<div>", { "class": "ganttview-hzheader" });
+            var monthsDiv = jQuery("<div>", { "class": "ganttview-hzheader-months" });
+            var daysDiv = jQuery("<div>", { "class": "ganttview-hzheader-days" });
+            var chunksDiv = jQuery("<div>", { "class": "ganttview-hzheader-chunks" });
+            var totalW = 0;
 
-        for (var y in dates) {
-            mCount = 0;
-            dates[y].forEach(function (m) {
-                var w = m.length * cellWidth * dateChunks;
-                totalW = totalW + w;
-                monthsDiv.append(jQuery("<div>", {
-                    "class": "ganttview-hzheader-month",
-                    "css": { "width": (w - 1) + "px" }
-                }).append(monthNames[mCount] + "/" + y));
+            for (var y in dates) {
+                mCount = 0;
+                dates[y].forEach(function (m) {
+                    var w = m.length * cellWidth * dateChunks;
+                    totalW = totalW + w;
+                    monthsDiv.append(jQuery("<div>", {
+                        "class": "ganttview-hzheader-month",
+                        "css": { "width": (w - 1) + "px" }
+                    }).append(monthNames[mCount] + "/" + y));
 
-                dCount = 1;
+                    dCount = 1;
 
-                m.forEach(function (d) {
-                    daysDiv.append(jQuery("<div>", { 
-                        "class": "ganttview-hzheader-day",
-                        "css": { "width": (cellWidth*dateChunks - 1) + "px" }
-                    }).append(dCount));
+                    m.forEach(function (d) {
+                        daysDiv.append(jQuery("<div>", { 
+                            "class": "ganttview-hzheader-day",
+                            "css": { "width": (cellWidth*dateChunks - 1) + "px" }
+                        }).append(dCount));
 
-                    if(dateChunk > 1){
-                        let hourMark = Math.parseInt(24/dateChunk);
+                        if(dateChunk > 1){
+                            let hourMark = Math.parseInt(24/dateChunk);
 
-                        for(var dateChunk=0; dateChunk < dateChunks; ++dateChunk){
-                            if (dateChunk%hourMark != 0){
-                                chunksDiv.append(jQuery("<div>", {
-                                    "class": "ganttview-hzheader-chunk",
-                                    "css": { "width": (cellWidth) + "px" }
-                                }) )
-                            }
-                            else {
-                                chunksDiv.append(jQuery("<div>", {
-                                    "class": "ganttview-hzheader-chunk",
-                                    "css": { "width": (cellWidth) + "px" }
-                                }).append(dateChunk));
+                            for(var dateChunk=0; dateChunk < dateChunks; ++dateChunk){
+                                if (dateChunk%hourMark != 0){
+                                    chunksDiv.append(jQuery("<div>", {
+                                        "class": "ganttview-hzheader-chunk",
+                                        "css": { "width": (cellWidth) + "px" }
+                                    }) )
+                                }
+                                else {
+                                    chunksDiv.append(jQuery("<div>", {
+                                        "class": "ganttview-hzheader-chunk",
+                                        "css": { "width": (cellWidth) + "px" }
+                                    }).append(dateChunk));
+                                }
                             }
                         }
-                    }
 
-                    ++dCount;
+                        ++dCount;
+                    })
+                    ++mCount;
                 })
-                ++mCount;
-            })
+            }
+
+            monthsDiv.css("width", totalW + "px");
+            daysDiv.css("width", totalW + "px");
+            chunksDiv.css("width", totalW + "px");
+            headerDiv.append(monthsDiv).append(daysDiv).append(chunksDiv);
+            div.append(headerDiv);
         }
 
-        monthsDiv.css("width", totalW + "px");
-        daysDiv.css("width", totalW + "px");
-        chunksDiv.css("width", totalW + "px");
-        headerDiv.append(monthsDiv).append(daysDiv).append(chunksDiv);
-        div.append(headerDiv);
-    }
-
-    function addGrid(div, data, dates, dateChunks, cellWidth, cellHeight, showWeekends, groupBySeries, groupById, groupByIdDrawAllTitles) {
-        var gridDiv = jQuery("<div>", { "class": "ganttview-grid" });
-        var rowDiv = jQuery("<div>", { "class": "ganttview-grid-row" }).css('height', cellHeight);
-        for (var y in dates) {
-            for (var m in dates[y]) {
-                for (var d in dates[y][m]) {
-                    for (var dateChunk = 0; dateChunk < dateChunks; ++dateChunk){
-                        var cellDiv = jQuery("<div>", { "class": "ganttview-grid-row-cell" });
-                        if (DateUtils.isWeekend(dates[y][m][d]) && showWeekends) { 
-                            cellDiv.addClass("ganttview-weekend"); 
+        function addGrid(div, data, dates, dateChunks, cellWidth, cellHeight, showWeekends, groupBySeries, groupById, groupByIdDrawAllTitles) {
+            var gridDiv = jQuery("<div>", { "class": "ganttview-grid" });
+            var rowDiv = jQuery("<div>", { "class": "ganttview-grid-row" }).css('height', cellHeight);
+            for (var y in dates) {
+                for (var m in dates[y]) {
+                    for (var d in dates[y][m]) {
+                        for (var dateChunk = 0; dateChunk < dateChunks; ++dateChunk){
+                            var cellDiv = jQuery("<div>", { "class": "ganttview-grid-row-cell" });
+                            if (DateUtils.isWeekend(dates[y][m][d]) && showWeekends) { 
+                                cellDiv.addClass("ganttview-weekend"); 
+                            }
+                            rowDiv.append(cellDiv);
                         }
-                        rowDiv.append(cellDiv);
                     }
                 }
             }
-        }
 
-        var rowIdx = 1;
-        var listId = {};
-        var w = jQuery("div.ganttview-grid-row-cell", rowDiv).length * cellWidth;
-        rowDiv.css("width", w + "px");
-        gridDiv.css("width", w + "px");
-        for (var i = 0; i < data.length; i++)
-        {
-            if(groupBySeries)
+            var rowIdx = 1;
+            var listId = {};
+            var w = jQuery("div.ganttview-grid-row-cell", rowDiv).length * cellWidth;
+            rowDiv.css("width", w + "px");
+            gridDiv.css("width", w + "px");
+            for (var i = 0; i < data.length; i++)
             {
-                var id = "" + data[i].id;
-                if(groupById && id.length > 0)
+                if(groupBySeries)
                 {
-                   if(typeof listId[ id ] === 'undefined')
-                   {
-                       gridDiv.append(rowDiv.clone());
+                    var id = "" + data[i].id;
+                    if(groupById && id.length > 0)
+                    {
+                       if(typeof listId[ id ] === 'undefined')
+                       {
+                           gridDiv.append(rowDiv.clone());
 
-                       listId[ id ] = {index: rowIdx, cnt: 0};
+                           listId[ id ] = {index: rowIdx, cnt: 0};
 
-                       rowIdx ++;
+                           rowIdx ++;
+                       }
+                       else
+                       {
+                         if(groupByIdDrawAllTitles)
+                         {
+                           listId[ id ].cnt ++;
+                           var itemRowDiv = gridDiv.children(':nth-child('+listId[ id ].index+')');
+                           itemRowDiv.css('height', listId[ id ].cnt * cellHeight);
+                           }
+                       }
                    }
                    else
                    {
-                     if(groupByIdDrawAllTitles)
-                     {
-                       listId[ id ].cnt ++;
-                       var itemRowDiv = gridDiv.children(':nth-child('+listId[ id ].index+')');
-                       itemRowDiv.css('height', listId[ id ].cnt * cellHeight);
+                       gridDiv.append(rowDiv.clone());
                    }
                }
-           }
-           else
-           {
-               gridDiv.append(rowDiv.clone());
-           }
-       }
-       else
-       {
-        for (var j = 0; j < data[i].series.length; j++)
-        {
-            gridDiv.append(rowDiv.clone());
-        }
-    }
-}
-div.append(gridDiv);
-}
-
-function addBlockContainers(div, data, cellHeight, groupBySeries, groupById, groupByIdDrawAllTitles) {
-    var rowIdx = 1;
-    var listId = {};
-    var blocksDiv = jQuery("<div>", { "class": "ganttview-blocks" });
-    for (var i = 0; i < data.length; i++)
-    {
-        if(groupBySeries)
-        {
-            var id = "" + data[i].id;
-            if(groupById && id.length > 0)
-            {
-                if(typeof listId[ id ] === 'undefined')
-                {
-                    blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));                         
-                    listId[ id ] = {index: rowIdx, cnt: 0};
-                    rowIdx ++;
+               else
+               {
+                    for (var j = 0; j < data[i].series.length; j++)
+                    {
+                        gridDiv.append(rowDiv.clone());
+                    }
                 }
+            }
+            div.append(gridDiv);
+        }
 
+        function addBlockContainers(div, data, cellHeight, groupBySeries, groupById, groupByIdDrawAllTitles) {
+            var rowIdx = 1;
+            var listId = {};
+            var blocksDiv = jQuery("<div>", { "class": "ganttview-blocks" });
+            for (var i = 0; i < data.length; i++)
+            {
+                if(groupBySeries)
+                {
+                    var id = "" + data[i].id;
+                    if(groupById && id.length > 0)
+                    {
+                        if(typeof listId[ id ] === 'undefined')
+                        {
+                            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));                         
+                            listId[ id ] = {index: rowIdx, cnt: 0};
+                            rowIdx ++;
+                        }
+
+                        else
+                        {
+                            if(groupByIdDrawAllTitles)
+                            {
+                                listId[ id ].cnt ++;
+                                var itemBlockDiv = blocksDiv.children(':nth-child('+listId[ id ].index+')');
+                                itemBlockDiv.css('height', listId[ id ].cnt * cellHeight - 3);
+                            }
+                        }
+                    }
+
+                    else
+                    {
+                        blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
+                    }
+                }
                 else
                 {
-                 if(groupByIdDrawAllTitles)
-                 {
-                    listId[ id ].cnt ++;
-                    var itemBlockDiv = blocksDiv.children(':nth-child('+listId[ id ].index+')');
-                    itemBlockDiv.css('height', listId[ id ].cnt * cellHeight - 3);
-                }
-            }
-        }
-
-        else
-        {
-            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
-        }
-    }
-    else
-    {
-        for (var j = 0; j < data[i].series.length; j++)
-        {
-            blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
-        }
-    }
-}
-div.append(blocksDiv);
-}
-
-function addBlocks(div, data, dateChunks, cellWidth, cellHeight, start, groupBySeries, groupById, groupByIdDrawAllTitles) {
-    var listId = {};
-    var rows = jQuery("div.ganttview-blocks div.ganttview-block-container", div);
-    var rowIdx = 0;
-
-    for (var i = 0; i < data.length; i++)
-    {
-        if(groupBySeries)
-        {
-            var id = "" + data[i].id;
-            if(groupById && id.length > 0)
-            {
-               if(typeof listId[ id ] == "undefined")
-               {
-                for (var j = 0; j < data[i].series.length; j++)
-                {
-                    var series = data[i].series[j];
-                    var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
-                    var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
-                    var block = jQuery("<div>", {
-                      "class": "ganttview-block",
-                      "title": series.name + ", " + size + " hrs",
-                      "css": {
-                          "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
-                          "width": ((size * cellWidth) - 9) + "px",
-                          "margin-left": ((offset * cellWidth) + 3) + "px",
-                          "top": 0
-                      }
-                  });
-                    addBlockData(block, data[i], series);
-                    if (data[i].series[j].color) {
-                        block.css("background-color", data[i].series[j].color);
+                    for (var j = 0; j < data[i].series.length; j++)
+                    {
+                        blocksDiv.append(jQuery("<div>", { "class": "ganttview-block-container" }));
                     }
-                    block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-                    jQuery(rows[rowIdx]).append(block);
                 }
-
-                listId[ id ] = rowIdx;
-
-                rowIdx = rowIdx + 1;
             }
-            else
+            div.append(blocksDiv);
+        }
+
+        function addBlocks(div, data, dateChunks, cellWidth, cellHeight, start, groupBySeries, groupById, groupByIdDrawAllTitles) {
+            var listId = {};
+            var rows = jQuery("div.ganttview-blocks div.ganttview-block-container", div);
+            var rowIdx = 0;
+
+            for (var i = 0; i < data.length; i++)
             {
-                for (var j = 0; j < data[i].series.length; j++)
+                if(groupBySeries)
                 {
-                    var series = data[i].series[j];
-                    var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
-                    var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
-                    var block = jQuery("<div>", {
-                      "class": "ganttview-block",
-                      "title": series.name + ", " + size + " days",
-                      "css": {
-                          "height": (parseInt(jQuery(rows[ listId[ id ] ]).css('height'), 10) - 4) + "px",
-                          "width": ((size * cellWidth) - 9) + "px",
-                          "margin-left": ((offset * cellWidth) + 3) + "px",
-                          "top": 0
-                      }
-                  });
-                    addBlockData(block, data[i], series);
-                    if (data[i].series[j].color) {
-                        block.css("background-color", data[i].series[j].color);
-                    }
-                    block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-                    jQuery(rows[ listId[ id ] ]).append(block);
-                }
-            }
-        }
-        else
-        {
-            for (var j = 0; j < data[i].series.length; j++)
-            {
-                var series = data[i].series[j];
-                var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
-                var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
-                var block = jQuery("<div>", {
-                  "class": "ganttview-block",
-                  "title": series.name + ", " + size + " days",
-                  "css": {
-                      "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
-                      "width": ((size * cellWidth) - 9) + "px",
-                      "margin-left": ((offset * cellWidth) + 3) + "px",
-                      "top": 0,
-                  }
-              });
-                addBlockData(block, data[i], series);
-                if (data[i].series[j].color) {
-                    block.css("background-color", data[i].series[j].color);
-                }
-                block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-                jQuery(rows[rowIdx]).append(block);
-            }
-            rowIdx = rowIdx + 1;
-        }
-    }
-    else
-    {
-        for (var j = 0; j < data[i].series.length; j++)
-        {
-            var series = data[i].series[j];
-            var size = DateUtils.daysBetween(series.start, series.end) + 1;
-            var offset = DateUtils.daysBetween(start, series.start);
-            var block = jQuery("<div>", {
-                "class": "ganttview-block",
-                "title": series.name + ", " + size + " days",
-                "css": {
-                    "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
-                    "width": ((size * cellWidth) - 9) + "px",
-                    "margin-left": ((offset * cellWidth) + 3) + "px",
-                    "top": "0px"
-                }
-            });
-            addBlockData(block, data[i], series);
-            if (data[i].series[j].color) {
-                block.css("background-color", data[i].series[j].color);
-            }
-            block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
-            jQuery(rows[rowIdx]).append(block);
-            rowIdx = rowIdx + 1;
-        }
-    }
-}
-}
+                    var id = "" + data[i].id;
+                    if(groupById && id.length > 0)
+                    {
+                       if(typeof listId[ id ] == "undefined")
+                        {
+                            for (var j = 0; j < data[i].series.length; j++)
+                            {
+                                var series = data[i].series[j];
+                                var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
+                                var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
+                                var block = jQuery("<div>", {
+                                  "class": "ganttview-block",
+                                  "title": series.name + ", " + size + " hrs",
+                                  "css": {
+                                      "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
+                                      "width": ((size * cellWidth) - 9) + "px",
+                                      "margin-left": ((offset * cellWidth) + 3) + "px",
+                                      "top": 0
+                                    }
+                                });
+                                addBlockData(block, data[i], series);
+                                if (data[i].series[j].color) {
+                                    block.css("background-color", data[i].series[j].color);
+                                }
+                                block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+                                jQuery(rows[rowIdx]).append(block);
+                            }
 
-function addBlockData(block, data, series) {
+                            listId[ id ] = rowIdx;
+
+                            rowIdx = rowIdx + 1;
+                        }
+                        else
+                        {
+                            for (var j = 0; j < data[i].series.length; j++)
+                            {
+                                var series = data[i].series[j];
+                                var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
+                                var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
+                                var block = jQuery("<div>", {
+                                  "class": "ganttview-block",
+                                  "title": series.name + ", " + size + " days",
+                                  "css": {
+                                      "height": (parseInt(jQuery(rows[ listId[ id ] ]).css('height'), 10) - 4) + "px",
+                                      "width": ((size * cellWidth) - 9) + "px",
+                                      "margin-left": ((offset * cellWidth) + 3) + "px",
+                                      "top": 0
+                                    }
+                                });
+                                addBlockData(block, data[i], series);
+                                if (data[i].series[j].color) {
+                                    block.css("background-color", data[i].series[j].color);
+                                }
+                                block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+                                jQuery(rows[ listId[ id ] ]).append(block);
+                            }
+                        }
+                    }
+                    else
+                    {
+                        for (var j = 0; j < data[i].series.length; j++)
+                        {
+                            var series = data[i].series[j];
+                            var size = (DateUtils.daysBetween(series.start, series.end) + 1) * dateChunks;
+                            var offset = DateUtils.daysBetween(start, series.start)*dateChunks;
+                            var block = jQuery("<div>", {
+                              "class": "ganttview-block",
+                              "title": series.name + ", " + size + " days",
+                              "css": {
+                                  "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
+                                  "width": ((size * cellWidth) - 9) + "px",
+                                  "margin-left": ((offset * cellWidth) + 3) + "px",
+                                  "top": 0,
+                              }
+                            });
+                            addBlockData(block, data[i], series);
+                            if (data[i].series[j].color) {
+                                block.css("background-color", data[i].series[j].color);
+                            }
+                            block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+                            jQuery(rows[rowIdx]).append(block);
+                        }
+                        rowIdx = rowIdx + 1;
+                    }
+                }
+                else
+                {
+                    for (var j = 0; j < data[i].series.length; j++)
+                    {
+                        var series = data[i].series[j];
+                        var size = DateUtils.daysBetween(series.start, series.end) + 1;
+                        var offset = DateUtils.daysBetween(start, series.start);
+                        var block = jQuery("<div>", {
+                            "class": "ganttview-block",
+                            "title": series.name + ", " + size + " days",
+                            "css": {
+                                "height": (parseInt(jQuery(rows[rowIdx]).css('height'), 10) - 4) + "px",
+                                "width": ((size * cellWidth) - 9) + "px",
+                                "margin-left": ((offset * cellWidth) + 3) + "px",
+                                "top": "0px"
+                            }
+                        });
+                        addBlockData(block, data[i], series);
+                        if (data[i].series[j].color) {
+                            block.css("background-color", data[i].series[j].color);
+                        }
+                        block.append(jQuery("<div>", { "class": "ganttview-block-text" }).text(size));
+                        jQuery(rows[rowIdx]).append(block);
+                        rowIdx = rowIdx + 1;
+                    }
+                }
+            }
+        }
+
+        function addBlockData(block, data, series) {
             // This allows custom attributes to be added to the series data objects
             // and makes them available to the 'data' argument of click, resize, and drag handlers
             var blockData = { id: data.id, name: data.name };
@@ -561,7 +561,7 @@ function addBlockData(block, data, series) {
             jQuery("div.ganttview-hzheader-days div.ganttview-hzheader-day:last-child", div).addClass("last");
             jQuery("div.ganttview-hzheader-months div.ganttview-hzheader-month:last-child", div).addClass("last");
         }
-        
+            
         return {
             render: render
         };
@@ -619,66 +619,70 @@ function addBlockData(block, data, series) {
             var scroll = container.scrollLeft();
             var offset = block.offset().left - container.offset().left - 1 + scroll;
 
-                    // Set new start date
-                    var dayInMS = 86400000;
-                    var chunkInMS = dayInMS/dateChunks;
+            // Set new start date
+            var dayInMS = 86400000;
+            var chunkInMS = dayInMS/dateChunks;
 
-                    var chunksFromStart = Math.round(offset / cellWidth);
-                    var newStart = new Date(startDate.getTime() + (chunksFromStart*chunkInMS));
-                    block.data("block-data").start = newStart;
+            var chunksFromStart = Math.round(offset / cellWidth);
+            var newStart = new Date(startDate.getTime() + (chunksFromStart*chunkInMS));
+            block.data("block-data").start = newStart;
 
-                    // Set new end date
-                    var width = block.outerWidth();
-                    var chunksFromStart = parseInt(width / cellWidth) + 1;
-                    block.data("block-data").end = new Date(newStart.clone().getTime() + (chunksFromStart*chunkInMS));
-                    jQuery("div.ganttview-block-text", block).text(chunksFromStart + 1);
-                    
-                    // Remove top and left properties to avoid incorrect block positioning,
-                    // set position to relative to keep blocks relative to scrollbar when scrolling
-                    block.css("top", "0").css("left", "")
-                    .css("position", "absolute").css("margin-left", offset + "px");
-                }
+            // Set new end date
+            var width = block.outerWidth();
+            var chunksFromStart = parseInt(width / cellWidth) + 1;
+            block.data("block-data").end = new Date(newStart.clone().getTime() + (chunksFromStart*chunkInMS));
+            jQuery("div.ganttview-block-text", block).text(chunksFromStart + 1);
+            
+            // Remove top and left properties to avoid incorrect block positioning,
+            // set position to relative to keep blocks relative to scrollbar when scrolling
+            block.css("top", "0").css("left", "")
+            .css("position", "absolute").css("margin-left", offset + "px");
+        }
 
-                return {
-                    apply: apply    
-                };
+        return {
+            apply: apply    
+        };
+    }
+
+    var ArrayUtils = {
+
+        contains: function (arr, obj) {
+            var has = false;
+
+            for (var i = 0; i < arr.length; i++) { 
+                if (arr[i] == obj) { has = true; } 
             }
 
-            var ArrayUtils = {
+            return has;
+        }
+    };
 
-                contains: function (arr, obj) {
-                    var has = false;
-                    for (var i = 0; i < arr.length; i++) { if (arr[i] == obj) { has = true; } }
-                        return has;
+    var DateUtils = {
+
+        daysBetween: function (start, end) {
+            if (!start || !end) { return 0; }
+            start = Date.parse(start); end = Date.parse(end);
+            if (start.getYear() == 1901 || end.getYear() == 8099) { return 0; }
+            var count = 0, date = start.clone();
+            while (date.compareTo(end) == -1) { count = count + 1; date.addDays(1); }
+            return count;
+        },
+
+        isWeekend: function (date) {
+            return date.getDay() % 6 == 0;
+        },
+
+        getBoundaryDatesFromData: function (data, minDays) {
+            var minStart = new Date(); maxEnd = new Date();
+            for (var i = 0; i < data.length; i++) {
+                for (var j = 0; j < data[i].series.length; j++) {
+                    var start = Date.parse(data[i].series[j].start);
+                    var end = Date.parse(data[i].series[j].end)
+                    if (i == 0 && j == 0) { minStart = start; maxEnd = end; }
+                    if (minStart.compareTo(start) == 1) { minStart = start; }
+                    if (maxEnd.compareTo(end) == -1) { maxEnd = end; }
                 }
-            };
-
-            var DateUtils = {
-
-                daysBetween: function (start, end) {
-                    if (!start || !end) { return 0; }
-                    start = Date.parse(start); end = Date.parse(end);
-                    if (start.getYear() == 1901 || end.getYear() == 8099) { return 0; }
-                    var count = 0, date = start.clone();
-                    while (date.compareTo(end) == -1) { count = count + 1; date.addDays(1); }
-                    return count;
-                },
-
-                isWeekend: function (date) {
-                    return date.getDay() % 6 == 0;
-                },
-
-                getBoundaryDatesFromData: function (data, minDays) {
-                    var minStart = new Date(); maxEnd = new Date();
-                    for (var i = 0; i < data.length; i++) {
-                        for (var j = 0; j < data[i].series.length; j++) {
-                            var start = Date.parse(data[i].series[j].start);
-                            var end = Date.parse(data[i].series[j].end)
-                            if (i == 0 && j == 0) { minStart = start; maxEnd = end; }
-                            if (minStart.compareTo(start) == 1) { minStart = start; }
-                            if (maxEnd.compareTo(end) == -1) { maxEnd = end; }
-                        }
-                    }
+            }
 
             // Insure that the width of the chart is at least the slide width to avoid empty
             // whitespace to the right of the grid

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -53,6 +53,7 @@ var dayInMS = 86400000;
             cellBuffer: 5, //number of cells to display prior to the start time
             dateChunks: 1, //default to day (how many chunks to split each day into [ie how many cells make up one day])
             freezeDate: null, //default to no freezeDate
+            displayGroupedTitles: true, //default to true
             updateDependencies: false, //default to false to maintain backwards compatibility
             cellWidth: 21,
             cellHeight: 31,
@@ -116,7 +117,7 @@ var dayInMS = 86400000;
 
         function render() {
 
-            addVtHeader(div, opts.data, opts.dateChunks, opts.cellHeight, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
+            addVtHeader(div, opts.data, opts.dateChunks, opts.cellHeight, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles, opts.displayGroupedTitles);
 
             var slideDiv = jQuery("<div>", {
                 "class": "ganttview-slide-container",
@@ -126,7 +127,7 @@ var dayInMS = 86400000;
             dates = getDates(opts.start, opts.end);
 
             addHzHeader(slideDiv, opts.start, dates, opts.dateChunks, opts.cellWidth);
-            addGrid(slideDiv, opts.data, dates, opts.dateChunks, opts.cellWidth, opts.cellHeight, opts.showWeekends, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
+            addGrid(slideDiv, opts.data, dates, opts.dateChunks, opts.freezeDate, opts.cellWidth, opts.cellHeight, opts.showWeekends, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
             addBlockContainers(slideDiv, opts.data, opts.dateChunks, opts.cellHeight, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
             addBlocks(slideDiv, opts.data, opts.dateChunks, opts.cellWidth, opts.cellHeight, opts.start, opts.groupBySeries, opts.groupById, opts.groupByIdDrawAllTitles);
             div.append(slideDiv);
@@ -158,7 +159,7 @@ var dayInMS = 86400000;
             return dates;
         }
 
-        function addVtHeader(div, data, dateChunks, cellHeight, groupBySeries, groupById, groupByIdDrawAllTitles) {
+        function addVtHeader(div, data, dateChunks, cellHeight, groupBySeries, groupById, groupByIdDrawAllTitles, displayGroupedTitles) {
             var listId = {};
             var rowIdx = 1;
             var vthHeight = 41;
@@ -191,13 +192,17 @@ var dayInMS = 86400000;
                                 "class": "ganttview-vtheader-item-name",
                                 "css": { "height": cellHeight + "px" }
                             }).append(data[i].name));
-                            var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
-                            var serieNames = new Array();
-                            for (var j = 0; j < data[i].series.length; j++)
-                            {
-                                serieNames.push(data[i].series[j].name);
+
+                            if(displayGroupedTitles){
+                                var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
+                                var seriesNames = new Array();
+                                for (var j = 0; j < data[i].series.length; j++)
+                                {
+                                    seriesNames.push(data[i].series[j].name);
+                                }
+                                seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(seriesNames.join(', ')));
                             }
-                            seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
+                            
                             itemDiv.append(seriesDiv);
                             headerDiv.append(itemDiv);
 
@@ -214,13 +219,15 @@ var dayInMS = 86400000;
                                 localCellHeight = cellHeight * (itemDiv.find('.ganttview-vtheader-item-name > br').length + 1);
                                 itemDiv.find('.ganttview-vtheader-item-name').append('<br />'+data[i].name).css('height', localCellHeight);
 
-                                var serieNames = new Array();
-                                for (var j = 0; j < data[i].series.length; j++)
-                                {
-                                    serieNames.push(data[i].series[j].name);
-                                }
+                                if(displayGroupedTitles){
+                                    var seriesNames = new Array();
+                                    for (var j = 0; j < data[i].series.length; j++)
+                                    {
+                                        seriesNames.push(data[i].series[j].name);
+                                    }
 
-                                itemDiv.find('.ganttview-vtheader-series-name').append('<br />'+serieNames.join(', ')).css('height', localCellHeight);
+                                    itemDiv.find('.ganttview-vtheader-series-name').append('<br />'+seriesNames.join(', ')).css('height', localCellHeight);
+                                }
                             }
                         }
                     }
@@ -231,13 +238,16 @@ var dayInMS = 86400000;
                             "class": "ganttview-vtheader-item-name",
                             "css": { "height": cellHeight + "px" }
                         }).append(data[i].name));
-                        var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
-                        var serieNames = new Array();
-                        for (var j = 0; j < data[i].series.length; j++)
-                        {
-                            serieNames.push(data[i].series[j].name);
+
+                        if(displayGroupedTitles){
+                            var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
+                            var seriesNames = new Array();
+                            for (var j = 0; j < data[i].series.length; j++)
+                            {
+                                seriesNames.push(data[i].series[j].name);
+                            }
+                            seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(seriesNames.join(', ')));
                         }
-                        seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" }).append(serieNames.join(', ')));
                         itemDiv.append(seriesDiv);
                         headerDiv.append(itemDiv);
                     }
@@ -249,11 +259,14 @@ var dayInMS = 86400000;
                         "class": "ganttview-vtheader-item-name",
                         "css": { "height": (data[i].series.length * cellHeight) + "px" }
                     }).append(data[i].name));
-                    var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
-                    for (var j = 0; j < data[i].series.length; j++)
-                    {
-                        seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" })
-                            .append(data[i].series[j].name));
+
+                    if(displayGroupedTitles){
+                        var seriesDiv = jQuery("<div>", { "class": "ganttview-vtheader-series" });
+                        for (var j = 0; j < data[i].series.length; j++)
+                        {
+                            seriesDiv.append(jQuery("<div>", { "class": "ganttview-vtheader-series-name" })
+                                .append(data[i].series[j].name));
+                        }
                     }
                     itemDiv.append(seriesDiv);
                     headerDiv.append(itemDiv);
@@ -338,19 +351,51 @@ var dayInMS = 86400000;
             div.append(headerDiv);
         }
 
-        function addGrid(div, data, dates, dateChunks, cellWidth, cellHeight, showWeekends, groupBySeries, groupById, groupByIdDrawAllTitles) {
+        function addGrid(div, data, dates, dateChunks, freezeDate, cellWidth, cellHeight, showWeekends, groupBySeries, groupById, groupByIdDrawAllTitles) {
             var gridDiv = jQuery("<div>", { "class": "ganttview-grid" });
             var rowDiv = jQuery("<div>", { "class": "ganttview-grid-row" }).css('height', cellHeight);
 
+            let isPriorToFreeze = true, isFreezeDate = false;
+            let freezeYear = freezeDate.getFullYear();
+            let freezeMonth = freezeDate.getMonth();
+            let freezeDay = freezeDate.getDate();
+
             for (var y in dates) {
+                if(freezeDate && isPriorToFreeze && y > freezeYear){ 
+                    isPriorToFreeze = false;
+                }
+
                 for (var m in dates[y]) {
+                    if(freezeDate && isPriorToFreeze && y == freezeYear && m > freezeMonth){
+                        isPriorToFreeze = false;
+                    }
+
                     for (var d in dates[y][m]) {
-                        let isWeekendBool = showWeekends && DateUtils.isWeekend(dates[y][m][d]);
+                        let thisDay = dates[y][m][d].clone();
+                        let isWeekendBool = showWeekends && DateUtils.isWeekend(thisDay);
+
+                        if (freezeDate && isPriorToFreeze && m == freezeMonth && thisDay.getDate() == freezeDay) {
+                            isPriorToFreeze = false;
+                            isFreezeDate = true;
+                        }
                         
                         for (var dateChunk = 0; dateChunk < dateChunks; ++dateChunk){
                             var cellDiv = jQuery("<div>", { "class": "ganttview-grid-row-cell" });
                             if (isWeekendBool) { 
                                 cellDiv.addClass("ganttview-weekend"); 
+                            }
+                            if(freezeDate && isPriorToFreeze) {
+                                cellDiv.addClass("ganttview-frozen");
+                            }
+                            else if (freezeDate && isFreezeDate) {
+                                let curTime = DateUtils.chunksToTime(dateChunk, dateChunks);
+
+                                if(curTime.hrs <= freezeDate.getHours() && curTime.mins <= freezeDate.getMinutes()){                                    
+                                    cellDiv.addClass("ganttview-frozen");
+                                }
+                                else{
+                                    isFreezeDate = false;
+                                }
                             }
                             rowDiv.append(cellDiv);
                         }

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -620,7 +620,8 @@ var dayInMS = 86400000;
 
             var endChanged = newEnd.valueOf()!=oldEnd.valueOf();
 
-            var newText = parseInt(DateUtils.timeInChunksBetween(newStart, newEnd, dateChunks)/dateChunks)+1;
+            var newDuration = DateUtils.chunksToTime(DateUtils.timeInChunksBetween(newStart, newEnd, dateChunks), dateChunks);
+            var newText = newDuration.hrs;
 
             updateBlockDataAndCss(block, newStart, newEnd, newText, offset);
             updatedData.push(block.data("block-data"));
@@ -679,7 +680,6 @@ var dayInMS = 86400000;
             var chunksFromOldDateToNewDate = DateUtils.timeInChunksBetween(oldDate, newDate, dateChunks);
             var offsetChunks = Math.floor(chunksFromOldDateToNewDate) - chunksFromOldDate;
 
-            console.log(offsetChunks);
             return chunksFromOldDateToNewDate - offsetChunks;
         }
 
@@ -687,7 +687,6 @@ var dayInMS = 86400000;
             var chunkInMS = dayInMS/dateChunks;
 
             return new Date(oldDate.clone().getTime() + (offsetChunks*chunkInMS));
-
         }
 
         function updateBlockDataAndCss(block, newStart, newEnd, newText, pixelOffset){

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -739,16 +739,14 @@ var dayInMS = 86400000;
                 offsetChunks = DateUtils.timeInChunksBetween(oldStart, prevEnd, dateChunks);
             }
 
-            var startChanged = newStart.valueOf()!=oldStart.valueOf();
-
             // Set new end date
             var oldEnd = block.data("block-data").end;
             var chunksFromStartToEnd = DateUtils.timeInChunksBetween(oldStart, oldEnd, dateChunks);
 
-            var newEnd = updateDate(oldEnd, chunksFromStartToEnd, dateChunks);
+            var newEnd = updateDate(oldEnd, offsetChunks, dateChunks);
 
 
-            var newText = parseInt(chunksFromStartToEnd/dateChunks)+1;
+            var newText = DateUtils.chunksToTime(chunksFromStartToEnd, dateChunks);
             var pixelOffset = parseFloat(block.css("margin-left")) + (offsetChunks*cellWidth);
 
             updateBlockDataAndCss(block, newStart, newEnd, newText, pixelOffset);

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -723,24 +723,11 @@ var dayInMS = 86400000;
             var chunksDiff = DateUtils.timeInChunksBetween(oldEnd, newEnd, dateChunks);
             //if nextSibling
             if(updateDependencies && index < childElementCount-1 && endChanged){
-                updateFollowing(offset + width, newEnd, chunksDiff, jQuery(parentChildren[index+1]), updatedData, dateChunks, cellWidth);
+                updateFollowing(offset + width, newEnd, index+1, childElementCount, parentChildren, chunksDiff, jQuery(parentChildren[index+1]), updatedData, dateChunks, cellWidth);
             }
         }
 
-        function updateFollowing(offset, prevEnd, offsetChunks, block, updatedData, dateChunks, cellWidth){
-            var parentChildren = block.parent().children();
-            var childElementCount = parentChildren.length;
-            var index;
-
-            let i=0;
-
-            while (!index && i<childElementCount){
-                if(parentChildren[i] == block[0]){
-                    index = i;
-                }
-                ++i;
-            }
-
+        function updateFollowing(offset, prevEnd, index, childElementCount, parentChildren, offsetChunks, block, updatedData, dateChunks, cellWidth){
             // Set new start date
             var oldStart = block.data("block-data").start
 
@@ -771,7 +758,7 @@ var dayInMS = 86400000;
 
             //if nextSibling
             if(index < childElementCount-1 && endChanged){
-                updateFollowing(pixelOffset + chunksFromStartToEnd*cellWidth, offsetChunks, jQuery(parentChildren[index+1]), updatedData, dateChunks, cellWidth);
+                updateFollowing(pixelOffset + chunksFromStartToEnd*cellWidth, newEnd, index+1, childElementCount, parentChildren, offsetChunks, jQuery(parentChildren[index+1]), updatedData, dateChunks, cellWidth);
             }
         }
 

--- a/jquery.ganttView.js
+++ b/jquery.ganttView.js
@@ -356,9 +356,11 @@ var dayInMS = 86400000;
             var rowDiv = jQuery("<div>", { "class": "ganttview-grid-row" }).css('height', cellHeight);
 
             let isPriorToFreeze = true, isFreezeDate = false;
-            let freezeYear = freezeDate.getFullYear();
-            let freezeMonth = freezeDate.getMonth();
-            let freezeDay = freezeDate.getDate();
+            if(freezeDate){
+                let freezeYear = freezeDate.getFullYear();
+                let freezeMonth = freezeDate.getMonth();
+                let freezeDay = freezeDate.getDate();
+            }
 
             for (var y in dates) {
                 if(freezeDate && isPriorToFreeze && y > freezeYear){ 


### PR DESCRIPTION
I know there are a lot of changes in here, but bear with me:
  - updated time increments to be arbitrarily small (set dateChunks to be however many chunks you want in a day: 24 would be hourly, 48 would be half hourly, 1440 would be minutes)
  - updated file formatting
  - added in markers for the new smaller time increments based on 24-hour time
  - added optional freezeDate which disallows the editing of tasks prior to the given datetime-
  - added an ignore tag feature to ignore data containing a certain tag (such as "delete": true)
  - added the option to have all tasks following the edited task be updated as well (so if you make the first task in a series start three hours later it will make all of the other tasks begin 3 hours later)

lines 56-64 of jquery.ganttview.js explains each additional feature to some extent
